### PR TITLE
feat: Power Engineer v1.0.0 production release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,8 @@ test-projects/
 
 # Planning docs
 PRD.md
-docs/
+docs/*.md
+!docs/CONTRIBUTING.md
 
 # Other agent/IDE tool directories
 .adal/
@@ -53,4 +54,3 @@ docs/
 .windsurf/
 .zencoder/
 skills/
-tests/

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Skills are installed directly — no scripts to run. Power Engineer also creates
 - **`.power-engineer/install-log.sh`** — audit log (re-runnable)
 - **`.power-engineer/brand.md`** — brand identity (if applicable)
 - **`.power-engineer/project-context.md`** — goals, team, conventions
+- **`.power-engineer/cheatsheet.md`** — installed skills quick reference
 
 ---
 
@@ -149,7 +150,7 @@ Skills are installed directly — no scripts to run. Power Engineer also creates
 
 ```
 power-engineer/
-├── SKILL.md                               ← thin router (~44 lines)
+├── SKILL.md                               ← thin router (~50 lines, 14 commands)
 └── references/
     ├── modules/                           ← composable instruction sets
     │   ├── scanner.md                     ← codebase analysis → ProjectProfile
@@ -170,7 +171,9 @@ power-engineer/
     │   ├── mobile.md                      ← Scanner → mobile framework skills
     │   ├── status.md                      ← state.json → drift report (read-only)
     │   ├── update.md                      ← drift detection → resolve → install
-    │   └── catalog-browse.md              ← interactive catalog browser
+    │   ├── catalog-browse.md              ← interactive catalog browser
+    │   ├── help.md                        ← installed skills with trigger phrases
+    │   └── configure.md                   ← manage preferences (security level, auto-update)
     ├── catalog/                           ← browsable skill documentation (16 files)
     │   ├── INDEX.md
     │   ├── core-methodology.md

--- a/README.md
+++ b/README.md
@@ -1,44 +1,9 @@
 # power-engineer-skills
 
-An intelligent Claude Code skill that scans your codebase, conducts an adaptive
-interview, and installs the optimal skill stack directly — no scripts to review
-or run manually.
+An intelligent Claude Code skill that scans your codebase, conducts an adaptive interview, and installs the optimal skill stack directly — no scripts to review or run manually.
 
 Built for software engineers, AI engineers, and R&D engineers.
-280+ skills catalogued across every major category, including 70+ security skills.
-
----
-
-## What it does
-
-Run it once at the start of any project. It:
-
-1. **Scans your codebase** — detects language, framework, SDKs, infrastructure,
-   cloud/database, brand assets, existing skills, team size, and project maturity
-2. **Asks only what it can't infer** — adaptive questionnaire skips questions
-   already answered by the scan (12 questions total, typically 5-7 asked)
-3. **Installs skills directly** — no script generation; skills are installed
-   in real-time with progress tracking and failure handling
-4. **Configures your project** — generates/merges CLAUDE.md, creates
-   `.power-engineer/` state directory, patches skills with project context
-5. **Tracks drift** — on re-run, detects what changed and recommends new skills
-
-### Questions covered
-
-| # | Topic | Auto-detected? |
-|---|-------|---------------|
-| Q1 | Project type | Yes (from framework + language) |
-| Q2 | Language/stack | Yes (from config files) |
-| Q3 | Framework | Yes (from config files) |
-| Q4 | Design needs | Always asked |
-| Q5 | Documentation needs | Always asked |
-| Q6 | Research/data needs | Always asked |
-| Q7 | Cloud/database | Yes (from dependencies) |
-| Q8 | Project phase | Always asked |
-| Q9 | Brand identity | Yes (from design tokens) |
-| Q10 | Team workflow | Yes (from git log + CI/CD) |
-| Q11 | Goals | Always asked |
-| Q12 | Security needs | Always asked |
+290+ skills catalogued across every major category, including 70+ security skills.
 
 ---
 
@@ -58,36 +23,115 @@ Claude Code, Codex, Cursor, Gemini CLI, and 8+ other agents.
 
 ---
 
-## Use it
+## Quick start (under 2 minutes)
 
-Open Claude Code in any project directory and say:
+**Step 1 — Install**
 
-> "Set up skills for this project"
+```bash
+npx skills@latest add kalshamsi/power-engineer-skills --skill power-engineer --global
+```
 
-or:
+**Step 2 — Run in any project**
 
-> "/power-engineer"
+Open Claude Code in your project directory and say:
 
-Claude will scan your project, ask adaptive questions, install skills directly,
-and configure your project.
+```
+/power-engineer
+```
 
-### Targeted commands
+**Step 3 — Done**
 
-Skip the full interview and go straight to a specific category:
+Power Engineer scans your codebase, asks 5–7 adaptive questions, and installs the right skills directly. No scripts. No copy-paste. Skills are active immediately.
 
-| Say this | What it does |
-|----------|-------------|
-| `power engineer quick` | Auto-detect stack, minimal questions, smart defaults |
-| `power engineer frontend` | Frontend/design skills only |
-| `power engineer backend` | Backend/API/database skills only |
-| `power engineer devops` | DevOps/infrastructure skills only |
-| `power engineer ai` | AI/LLM/agentic skills only |
-| `power engineer data` | Data/ML/research skills only |
-| `power engineer docs` | Documentation skills only |
-| `power engineer mobile` | Mobile development skills only |
-| `power engineer status` | Show installed skills + drift report |
-| `power engineer catalog` | Browse catalog interactively |
-| `power engineer update` | Detect changes, install new skills |
+---
+
+## What is this? (Beginner guide)
+
+### What are Claude Code skills?
+
+Claude Code skills are reusable instruction sets that extend what Claude can do inside your project. Each skill gives Claude a specialized workflow — for example, a `test-driven-development` skill teaches Claude the exact TDD loop to follow when writing code, and a `systematic-debugging` skill gives it a structured approach to diagnosing bugs.
+
+Skills are installed per-project (or globally) and referenced in your `CLAUDE.md`. Once installed, you trigger them by name: `/skill-name` in chat, or they activate automatically when Claude detects the right context.
+
+### What does Power Engineer do?
+
+Instead of manually researching, picking, and installing individual skills one by one, Power Engineer does it all in a single run:
+
+1. **Scans your codebase** — detects language, framework, SDKs, infrastructure, cloud/database, brand assets, existing skills, team size, and project maturity
+2. **Asks only what it can't infer** — adaptive questionnaire skips questions already answered by the scan (12 questions total, typically 5–7 asked)
+3. **Installs skills directly** — no script generation; skills are installed in real-time with progress tracking and failure handling
+4. **Configures your project** — generates/merges CLAUDE.md, creates `.power-engineer/` state directory, patches skills with project context
+5. **Tracks drift** — on re-run, detects what changed and recommends new skills
+
+### Why would you want it?
+
+- You start a new project and don't know which Claude Code skills are relevant
+- You want your whole AI toolchain set up in one command, not assembled piece by piece
+- You want skills configured with your actual project context (repo name, stack, conventions), not generic defaults
+- You want drift detection: when your stack evolves, Power Engineer tells you what new skills to add
+
+---
+
+## Command reference
+
+| Command | Description |
+|---------|-------------|
+| `power-engineer` | Full interview: scan → adaptive questionnaire → install → configure |
+| `quick` | Auto-detect stack, minimal questions, smart defaults |
+| `frontend` | Frontend/design skills only |
+| `backend` | Backend/API/database skills only |
+| `devops` | DevOps/infrastructure skills only |
+| `ai` | AI/LLM/agentic skills only |
+| `data` | Data/ML/research skills only |
+| `docs` | Documentation skills only |
+| `mobile` | Mobile development skills only |
+| `status` | Show installed skills + drift report |
+| `update` | Detect changes, install new skills |
+| `catalog` | Browse catalog interactively |
+| `help` | Show command reference and usage hints |
+| `configure` | Re-run configuration step only (CLAUDE.md + state dir) |
+
+Trigger any command by saying `power engineer <command>` in Claude Code chat, or use the slash trigger: `/power-engineer`.
+
+---
+
+## Skills catalog
+
+290+ skills catalogued across every major category. Browse by category in [power-engineer/references/catalog/](./power-engineer/references/catalog/). Start with [INDEX.md](./power-engineer/references/catalog/INDEX.md) for an overview.
+
+### Categories
+
+| Category | Sub-categories |
+|----------|---------------|
+| **Core & Planning** | obra/superpowers, mattpocock planning, GitHub copilot |
+| **Anthropic Official** | Document generation, design, skill creation |
+| **Engineering** | Backend, DevOps/Infra, Data/ML, Testing, Agentic AI |
+| **Security & AppSec** | SAST, DAST, SCA, secrets, containers, IaC, threat modeling, compliance, pentest, DFIR, MCP servers |
+| **Frontend & Design** | React/Next.js, Vue/Vite, Design systems, Mobile |
+| **Cloud & Databases** | Microsoft Azure, Neon, Supabase |
+| **Docs & Research** | Technical writing, web research, data analysis |
+| **Power Suites** | GSD, Superpowers, UI/UX Pro Max, Designer Skills, Stitch, Pencil |
+
+---
+
+## What it does
+
+### Questions covered
+
+| # | Topic | Auto-detected? |
+|---|-------|---------------|
+| Q1 | Project type | Yes (from framework + language) |
+| Q2 | Language/stack | Yes (from config files) |
+| Q3 | Framework | Yes (from config files) |
+| Q4 | Design needs | Always asked |
+| Q5 | Documentation needs | Always asked |
+| Q6 | Research/data needs | Always asked |
+| Q7 | Cloud/database | Yes (from dependencies) |
+| Q8 | Project phase | Always asked |
+| Q9 | Brand identity | Yes (from design tokens) |
+| Q10 | Team workflow | Yes (from git log + CI/CD) |
+| Q11 | Goals | Always asked |
+| Q12 | Security needs | Always asked |
 
 ### After setup
 
@@ -151,26 +195,6 @@ The **Drift Detector** runs independently on `status` and `update` commands.
 
 ---
 
-## Skills catalog
-
-Browse the catalog by category in [power-engineer/references/catalog/](./power-engineer/references/catalog/).
-Start with [INDEX.md](./power-engineer/references/catalog/INDEX.md) for an overview.
-
-### Categories
-
-| Category | Sub-categories |
-|----------|---------------|
-| **Core & Planning** | obra/superpowers, mattpocock planning, GitHub copilot |
-| **Anthropic Official** | Document generation, design, skill creation |
-| **Engineering** | Backend, DevOps/Infra, Data/ML, Testing, Agentic AI |
-| **Security & AppSec** | SAST, DAST, SCA, secrets, containers, IaC, threat modeling, compliance, pentest, DFIR, MCP servers |
-| **Frontend & Design** | React/Next.js, Vue/Vite, Design systems, Mobile |
-| **Cloud & Databases** | Microsoft Azure, Neon, Supabase |
-| **Docs & Research** | Technical writing, web research, data analysis |
-| **Power Suites** | GSD, Superpowers, UI/UX Pro Max, Designer Skills, Stitch, Pencil |
-
----
-
 ## Power suites
 
 Some skill collections install via special methods rather than `npx skills add`.
@@ -215,14 +239,13 @@ The full security catalog (70+ skills, 60+ MCP servers) is browsable via
 
 ## Contributing
 
-PRs welcome. If you find a skill worth adding to the catalog, open an issue or
-submit a PR updating the relevant file in `power-engineer/references/catalog/`
-and the corresponding section in `power-engineer/references/modules/skill-resolver.md`.
+See [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) for the full contributor guide,
+including how to add skills to the catalog, improve the tool, and submit PRs.
 
-Please include:
-- Skill name and source repo
-- Verified install command (must use `--skill` flag syntax)
-- One-line description
+Quick summary:
+- Catalog additions go in `power-engineer/references/catalog/`
+- Follow the 6-column table format: Skill | Source | Install | Description | Trigger | When to use
+- Run `bash tests/run-tests.sh` before submitting
 
 ---
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,202 @@
+# Contributing to power-engineer-skills
+
+---
+
+## How to add skills to the catalog
+
+### Find the right catalog file
+
+All catalog files live in `power-engineer/references/catalog/`. Use `INDEX.md` to find the right sub-file for the skill you want to add:
+
+| Category | File |
+|----------|------|
+| Core & Planning | `core-methodology.md` |
+| Anthropic Official | `anthropic-official.md` |
+| Backend / API / Databases | `engineering/backend-architecture.md` |
+| DevOps / Infra / CI | `engineering/devops-infra.md` |
+| Data / ML / MLOps | `engineering/data-ml.md` |
+| Testing / Quality | `engineering/testing-quality.md` |
+| AI / LLM / Agentic | `engineering/agentic-ai.md` |
+| Security / AppSec | `engineering/security-ops.md` |
+| React / Next.js | `frontend/react-next.md` |
+| Vue / Vite / Nuxt | `frontend/vue-vite.md` |
+| Design Systems | `frontend/design-systems.md` |
+| Mobile (Expo / RN / iOS) | `frontend/mobile.md` |
+| Azure | `cloud/azure.md` |
+| Databases (Neon, Supabase) | `cloud/databases.md` |
+| Docs & Research | `docs-research.md` |
+| Power Suites | `power-suites.md` |
+
+### Table format
+
+Every skill entry follows this 6-column format:
+
+```
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+```
+
+### Required fields
+
+All 6 columns must be filled. No column may be left blank or contain a placeholder.
+
+| Column | Description | Example |
+|--------|-------------|---------|
+| **Skill** | Display name of the skill | `systematic-debugging` |
+| **Source** | GitHub user/repo | `anthropics/claude-code-skills` |
+| **Install** | Full install command (see syntax below) | `npx skills@latest add anthropics/claude-code-skills --skill systematic-debugging -y` |
+| **Description** | One-sentence description of what the skill does | "Structured debugging loop: reproduce, isolate, fix, verify." |
+| **Trigger** | How the skill is invoked | `/systematic-debugging` |
+| **When to use** | One-line usage hint | "When a bug is hard to reproduce or the root cause is unclear." |
+
+### Install command syntax
+
+```
+npx skills@latest add <user/repo> --skill <name> -y
+```
+
+- `<user/repo>` — GitHub username and repository, e.g. `kalshamsi/power-engineer-skills`
+- `--skill <name>` — exact skill name as it appears in the repo
+- `-y` — accept all prompts automatically (required for catalog entries)
+
+The install command must be verified to work before submitting. Test it in a clean environment.
+
+### Trigger format
+
+- `/skill-name` — manually triggered by the user saying `/skill-name` in chat
+- `auto` — skill activates automatically when Claude detects the right context (no manual trigger needed)
+
+### When to use
+
+Write a one-line usage hint. Start with "When" or an action verb:
+
+- "When implementing a new API endpoint from scratch."
+- "When a security review is needed before merging."
+- "Debugging production incidents with live traces."
+
+---
+
+## How to improve the tool
+
+### Module architecture
+
+The tool is composed of independent modules in `power-engineer/references/modules/`:
+
+| Module | File | Responsibility |
+|--------|------|---------------|
+| **Scanner** | `scanner.md` | Analyzes the codebase and produces a `ProjectProfile` |
+| **Questionnaire** | `questionnaire.md` | Runs the adaptive interview and produces a `SkillPlan` |
+| **Skill Resolver** | `skill-resolver.md` | Converts a `SkillPlan` into a deduplicated list of install commands |
+| **Installer** | `installer.md` | Executes installs directly with progress tracking and failure handling |
+| **Configurator** | `configurator.md` | Writes/merges CLAUDE.md, creates `.power-engineer/` state directory, patches skills with project context |
+| **Drift Detector** | `drift-detector.md` | Compares `.power-engineer/state.json` against the current project to surface new skill recommendations |
+
+Keep modules focused on a single responsibility. Do not add routing logic to a module; that belongs in a flow.
+
+### Flow composition
+
+Flows live in `power-engineer/references/flows/`. A flow composes modules from the pipeline:
+
+```
+Scanner → Questionnaire → Skill Resolver → Installer → Configurator
+```
+
+The Drift Detector runs independently on `status` and `update` commands only.
+
+When adding a new command route:
+1. Create a new flow file in `flows/`
+2. Specify exactly which modules it calls and in what order
+3. Add the trigger mapping to `SKILL.md`
+4. Document the command in `README.md` under the command reference table
+
+### Testing requirements
+
+Tests use the `check()` bash pattern. All integration tests live in `tests/integration/`.
+
+Basic pattern:
+
+```bash
+check() {
+  local description="$1"
+  local result="$2"
+  local expected="$3"
+  if echo "$result" | grep -q "$expected"; then
+    echo "PASS: $description"
+  else
+    echo "FAIL: $description"
+    echo "  Expected: $expected"
+    echo "  Got: $result"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+```
+
+Run all tests with:
+
+```bash
+bash tests/run-tests.sh
+```
+
+Run a single integration test with:
+
+```bash
+bash tests/integration/test-<name>.sh
+```
+
+Tests must pass before a PR is merged. Do not add tests to the root folder.
+
+### File organization
+
+| Type | Location |
+|------|----------|
+| Source modules | `power-engineer/references/modules/` |
+| Flow compositions | `power-engineer/references/flows/` |
+| Catalog files | `power-engineer/references/catalog/` |
+| Integration tests | `tests/integration/` |
+| Documentation | `docs/` |
+| Scripts | `scripts/` |
+
+Keep `SKILL.md` under 55 lines. It is a thin router — move logic into modules, not the router.
+
+Keep modules focused. If a module grows beyond 500 lines, split it.
+
+---
+
+## PR guidelines
+
+### Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add semgrep-pro skill to security catalog
+fix: correct install command for playwright-testing
+docs: update CONTRIBUTING with trigger format rules
+refactor: extract scanner logic into sub-module
+test: add integration test for drift-detector
+```
+
+### Before submitting
+
+1. Run all tests: `bash tests/run-tests.sh`
+2. Verify the build succeeds: `npm run build`
+3. Confirm your install command works end-to-end in a clean environment
+
+### Catalog additions
+
+- One skill per PR
+- All 6 columns filled (Skill, Source, Install, Description, Trigger, When to use)
+- Install command must be verified and include `-y`
+- Update the skill count in `power-engineer/references/catalog/INDEX.md`
+
+### Module/flow changes
+
+- Describe what the module does, why the change is needed, and any downstream impact on flows
+- Include a test covering the change
+- If adding a new command route, update the command reference table in `README.md`
+
+### What not to include
+
+- Hardcoded secrets, API keys, or credentials
+- `.env` files or anything derived from them
+- Files saved to the root folder (use `docs/`, `tests/`, `scripts/` instead)

--- a/power-engineer/SKILL.md
+++ b/power-engineer/SKILL.md
@@ -35,6 +35,7 @@ Check the user's message and follow the matching route:
 | "power engineer status"                  | Read `references/modules/drift-detector.md` (read-only)   |
 | "power engineer update"                  | Read `references/flows/update.md`                         |
 | "power engineer catalog"                 | Read `references/flows/catalog-browse.md`                 |
+| "power engineer help"                   | Read `references/flows/help.md`                           |
 | "power engineer frontend"               | Read `references/flows/frontend.md`                       |
 | "power engineer backend"                | Read `references/flows/backend.md`                        |
 | "power engineer devops"                 | Read `references/flows/devops.md`                         |

--- a/power-engineer/SKILL.md
+++ b/power-engineer/SKILL.md
@@ -36,6 +36,7 @@ Check the user's message and follow the matching route:
 | "power engineer update"                  | Read `references/flows/update.md`                         |
 | "power engineer catalog"                 | Read `references/flows/catalog-browse.md`                 |
 | "power engineer help"                   | Read `references/flows/help.md`                           |
+| "power engineer configure"             | Read `references/flows/configure.md`                      |
 | "power engineer frontend"               | Read `references/flows/frontend.md`                       |
 | "power engineer backend"                | Read `references/flows/backend.md`                        |
 | "power engineer devops"                 | Read `references/flows/devops.md`                         |

--- a/power-engineer/references/catalog/INDEX.md
+++ b/power-engineer/references/catalog/INDEX.md
@@ -37,5 +37,5 @@ Each file is self-contained with skill tables, install commands, and scope.
 
 ---
 
-*Total skills catalogued: 280+*
+*Total skills catalogued: 290+*
 *Last updated: March 2026*

--- a/power-engineer/references/catalog/anthropic-official.md
+++ b/power-engineer/references/catalog/anthropic-official.md
@@ -2,27 +2,27 @@
 
 ## Anthropic Official — anthropics/skills
 
-| Skill | Install | Description |
-|-------|---------|-------------|
-| skill-creator | `npx skills@latest add anthropics/skills --skill skill-creator -y` | Official skill authoring guide with progressive disclosure patterns. |
-| mcp-builder | `npx skills@latest add anthropics/skills --skill mcp-builder -y` | Builds MCP servers from scratch: tool schema, transport config, auth, deployment. |
-| frontend-design | `npx skills@latest add anthropics/skills --skill frontend-design -y` | Production-grade UI skill. Creates distinctive, accessible frontend interfaces. |
-| pdf | `npx skills@latest add anthropics/skills --skill pdf -y` | PDF manipulation: text extraction, merging, splitting, form filling, OCR, watermarks. |
-| docx | `npx skills@latest add anthropics/skills --skill docx -y` | Creates and edits Word documents with headers, tables, tracked changes, formatting. |
-| pptx | `npx skills@latest add anthropics/skills --skill pptx -y` | Builds polished PowerPoint presentations with layouts, speaker notes, themes. |
-| xlsx | `npx skills@latest add anthropics/skills --skill xlsx -y` | Creates and manipulates Excel spreadsheets with formulas, pivot tables, formatting. |
-| webapp-testing | `npx skills@latest add anthropics/skills --skill webapp-testing -y` | E2E web app testing strategies with browser automation and assertion patterns. |
-| canvas-design | `npx skills@latest add anthropics/skills --skill canvas-design -y` | HTML canvas design for generative art and interactive visualisations. |
-| algorithmic-art | `npx skills@latest add anthropics/skills --skill algorithmic-art -y` | Creates algorithmic and generative art using code. |
-| brand-guidelines | `npx skills@latest add anthropics/skills --skill brand-guidelines -y` | Applies brand colours, typography, and style guidelines to artifacts. |
-| internal-comms | `npx skills@latest add anthropics/skills --skill internal-comms -y` | Writes internal communications: status reports, newsletters, FAQs. |
+| Skill | Install | Description | Trigger | When to use |
+|-------|---------|-------------|---------|-------------|
+| skill-creator | `npx skills@latest add anthropics/skills --skill skill-creator -y` | Official skill authoring guide with progressive disclosure patterns. | `/skill-creator` | When building a new Claude skill following official patterns |
+| mcp-builder | `npx skills@latest add anthropics/skills --skill mcp-builder -y` | Builds MCP servers from scratch: tool schema, transport config, auth, deployment. | `/mcp-builder` | When creating a new MCP server with tools, auth, or transport |
+| frontend-design | `npx skills@latest add anthropics/skills --skill frontend-design -y` | Production-grade UI skill. Creates distinctive, accessible frontend interfaces. | `/frontend-design` | When building production-quality accessible UI components |
+| pdf | `npx skills@latest add anthropics/skills --skill pdf -y` | PDF manipulation: text extraction, merging, splitting, form filling, OCR, watermarks. | `/pdf` | When reading, merging, splitting, or filling PDF documents |
+| docx | `npx skills@latest add anthropics/skills --skill docx -y` | Creates and edits Word documents with headers, tables, tracked changes, formatting. | `/docx` | When generating or editing Word documents programmatically |
+| pptx | `npx skills@latest add anthropics/skills --skill pptx -y` | Builds polished PowerPoint presentations with layouts, speaker notes, themes. | `/pptx` | When generating presentation slides from content or data |
+| xlsx | `npx skills@latest add anthropics/skills --skill xlsx -y` | Creates and manipulates Excel spreadsheets with formulas, pivot tables, formatting. | `/xlsx` | When generating or transforming Excel spreadsheets |
+| webapp-testing | `npx skills@latest add anthropics/skills --skill webapp-testing -y` | E2E web app testing strategies with browser automation and assertion patterns. | `/webapp-testing` | When designing E2E test coverage for a web application |
+| canvas-design | `npx skills@latest add anthropics/skills --skill canvas-design -y` | HTML canvas design for generative art and interactive visualisations. | `/canvas-design` | When creating generative art or interactive canvas visualisations |
+| algorithmic-art | `npx skills@latest add anthropics/skills --skill algorithmic-art -y` | Creates algorithmic and generative art using code. | `/algorithmic-art` | When generating visual art through code-driven algorithms |
+| brand-guidelines | `npx skills@latest add anthropics/skills --skill brand-guidelines -y` | Applies brand colours, typography, and style guidelines to artifacts. | `/brand-guidelines` | When ensuring output matches an established brand identity |
+| internal-comms | `npx skills@latest add anthropics/skills --skill internal-comms -y` | Writes internal communications: status reports, newsletters, FAQs. | `/internal-comms` | When drafting status reports, newsletters, or internal FAQs |
 
 ---
 
 ## Meta / Skill Creation
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| skill-creator | anthropics/skills | `npx skills@latest add anthropics/skills --skill skill-creator -y` | Official Anthropic skill authoring guide with progressive disclosure. |
-| mcp-builder | anthropics/skills | `npx skills@latest add anthropics/skills --skill mcp-builder -y` | Builds MCP servers from scratch. |
-| write-a-skill | mattpocock/skills | `npx skills@latest add mattpocock/skills --skill write-a-skill -y` | Opinionated skill authoring workflow with bundled resource patterns. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| skill-creator | anthropics/skills | `npx skills@latest add anthropics/skills --skill skill-creator -y` | Official Anthropic skill authoring guide with progressive disclosure. | `/skill-creator` | When authoring a new skill following Anthropic's official guide |
+| mcp-builder | anthropics/skills | `npx skills@latest add anthropics/skills --skill mcp-builder -y` | Builds MCP servers from scratch. | `/mcp-builder` | When scaffolding a new MCP server from scratch |
+| write-a-skill | mattpocock/skills | `npx skills@latest add mattpocock/skills --skill write-a-skill -y` | Opinionated skill authoring workflow with bundled resource patterns. | `/write-a-skill` | When creating a skill with bundled resources and opinionated structure |

--- a/power-engineer/references/catalog/cloud/azure.md
+++ b/power-engineer/references/catalog/cloud/azure.md
@@ -1,14 +1,14 @@
 # Microsoft Azure
 
-| Skill | Scope | Install | Description |
-|-------|-------|---------|-------------|
-| azure-ai | `local` | `npx skills@latest add microsoft/github-copilot-for-azure --skill azure-ai -y` | Azure AI Services: Cognitive Services, OpenAI on Azure, AI Search, model deployment. |
-| azure-observability | `local` | `npx skills@latest add microsoft/github-copilot-for-azure --skill azure-observability -y` | Monitoring AI workloads: token usage tracking, latency dashboards, cost attribution. |
-| azure-compute | `local` | `npx skills@latest add microsoft/github-copilot-for-azure --skill azure-compute -y` | Azure VM, container, and serverless compute patterns and sizing guidance. |
-| azure-postgres | `local` | `npx skills@latest add microsoft/github-copilot-for-azure --skill azure-postgres -y` | Azure Database for PostgreSQL: setup, scaling, connection pooling, migration. |
-| azure-cloud-migrate | `local` | `npx skills@latest add microsoft/github-copilot-for-azure --skill azure-cloud-migrate -y` | Cloud migration strategy, assessment, and lift-and-shift patterns. |
-| azure-hosted-copilot-sdk | `local` | `npx skills@latest add microsoft/github-copilot-for-azure --skill azure-hosted-copilot-sdk -y` | Azure-hosted Copilot SDK: extensions, plugins, custom copilot integration. |
-| microsoft-foundry | `local` | `npx skills@latest add microsoft/azure-skills --skill microsoft-foundry -y` | Azure AI Foundry: model fine-tuning, evaluation pipelines, production serving. |
-| azure-quotas | `local` | `npx skills@latest add microsoft/azure-skills --skill azure-quotas -y` | Azure quota management, increase requests, and capacity planning. |
-| azure-upgrade | `local` | `npx skills@latest add microsoft/azure-skills --skill azure-upgrade -y` | Azure service upgrades, deprecation handling, and migration paths. |
-| azure-observability (azure-skills) | `local` | `npx skills@latest add microsoft/azure-skills --skill azure-observability -y` | Azure Monitor, Log Analytics, Application Insights for cloud workloads. |
+| Skill | Scope | Install | Description | Trigger | When to use |
+|-------|-------|---------|-------------|---------|-------------|
+| azure-ai | `local` | `npx skills@latest add microsoft/github-copilot-for-azure --skill azure-ai -y` | Azure AI Services: Cognitive Services, OpenAI on Azure, AI Search, model deployment. | `/azure-ai` | When deploying AI models or integrating Azure Cognitive Services |
+| azure-observability | `local` | `npx skills@latest add microsoft/github-copilot-for-azure --skill azure-observability -y` | Monitoring AI workloads: token usage tracking, latency dashboards, cost attribution. | `/azure-observability` | When monitoring AI workload costs, latency, and token usage on Azure |
+| azure-compute | `local` | `npx skills@latest add microsoft/github-copilot-for-azure --skill azure-compute -y` | Azure VM, container, and serverless compute patterns and sizing guidance. | `/azure-compute` | When selecting and sizing Azure compute (VM, containers, serverless) |
+| azure-postgres | `local` | `npx skills@latest add microsoft/github-copilot-for-azure --skill azure-postgres -y` | Azure Database for PostgreSQL: setup, scaling, connection pooling, migration. | `/azure-postgres` | When setting up or migrating Azure Database for PostgreSQL |
+| azure-cloud-migrate | `local` | `npx skills@latest add microsoft/github-copilot-for-azure --skill azure-cloud-migrate -y` | Cloud migration strategy, assessment, and lift-and-shift patterns. | `/azure-cloud-migrate` | When planning a cloud migration to Azure with lift-and-shift strategy |
+| azure-hosted-copilot-sdk | `local` | `npx skills@latest add microsoft/github-copilot-for-azure --skill azure-hosted-copilot-sdk -y` | Azure-hosted Copilot SDK: extensions, plugins, custom copilot integration. | `/azure-hosted-copilot-sdk` | When building custom Copilot extensions or plugins on Azure |
+| microsoft-foundry | `local` | `npx skills@latest add microsoft/azure-skills --skill microsoft-foundry -y` | Azure AI Foundry: model fine-tuning, evaluation pipelines, production serving. | `/microsoft-foundry` | When fine-tuning models or running evaluation pipelines on Azure AI Foundry |
+| azure-quotas | `local` | `npx skills@latest add microsoft/azure-skills --skill azure-quotas -y` | Azure quota management, increase requests, and capacity planning. | `/azure-quotas` | When hitting Azure quota limits or planning capacity increases |
+| azure-upgrade | `local` | `npx skills@latest add microsoft/azure-skills --skill azure-upgrade -y` | Azure service upgrades, deprecation handling, and migration paths. | `/azure-upgrade` | When navigating Azure service deprecations or upgrade paths |
+| azure-observability (azure-skills) | `local` | `npx skills@latest add microsoft/azure-skills --skill azure-observability -y` | Azure Monitor, Log Analytics, Application Insights for cloud workloads. | `/azure-observability` | When setting up Azure Monitor or Application Insights for a workload |

--- a/power-engineer/references/catalog/cloud/databases.md
+++ b/power-engineer/references/catalog/cloud/databases.md
@@ -1,7 +1,7 @@
 # Databases
 
-| Skill | Source | Scope | Install | Description |
-|-------|--------|-------|---------|-------------|
-| neon-postgres | neondatabase/agent-skills | `local` | `npx skills@latest add neondatabase/agent-skills --skill neon-postgres -y` | Neon serverless Postgres: branching, vector search with pgvector, edge deployment. |
-| supabase-postgres-best-practices | supabase/agent-skills | `local` | `npx skills@latest add supabase/agent-skills --skill supabase-postgres-best-practices -y` | Supabase Postgres: RLS, realtime subscriptions, storage, edge functions, AI integrations. |
-| better-auth-best-practices | better-auth/skills | `local` | `npx skills@latest add better-auth/skills --skill better-auth-best-practices -y` | Better Auth library: sessions, OAuth, multi-tenancy, TypeScript-first patterns. |
+| Skill | Source | Scope | Install | Description | Trigger | When to use |
+|-------|--------|-------|---------|-------------|---------|-------------|
+| neon-postgres | neondatabase/agent-skills | `local` | `npx skills@latest add neondatabase/agent-skills --skill neon-postgres -y` | Neon serverless Postgres: branching, vector search with pgvector, edge deployment. | `/neon-postgres` | When using Neon serverless Postgres with branching or pgvector |
+| supabase-postgres-best-practices | supabase/agent-skills | `local` | `npx skills@latest add supabase/agent-skills --skill supabase-postgres-best-practices -y` | Supabase Postgres: RLS, realtime subscriptions, storage, edge functions, AI integrations. | `/supabase-postgres-best-practices` | When building on Supabase with RLS, realtime, or edge functions |
+| better-auth-best-practices | better-auth/skills | `local` | `npx skills@latest add better-auth/skills --skill better-auth-best-practices -y` | Better Auth library: sessions, OAuth, multi-tenancy, TypeScript-first patterns. | `/better-auth-best-practices` | When implementing auth with the Better Auth TypeScript library |

--- a/power-engineer/references/catalog/core-methodology.md
+++ b/power-engineer/references/catalog/core-methodology.md
@@ -5,22 +5,22 @@
 Always recommended. These skills form a complete agentic development workflow
 that auto-activates at each stage without manual invocation.
 
-| Skill | Description |
-|-------|-------------|
-| brainstorming | Refines rough ideas through structured Q&A, explores alternatives, presents design in sections for validation. |
-| writing-plans | Breaks approved designs into 2-5 minute tasks with exact file paths, complete code, and verification steps. |
-| test-driven-development | Enforces RED-GREEN-REFACTOR. Write failing test, watch it fail, write minimal code, commit. |
-| systematic-debugging | Hypothesis-driven root cause analysis. Auto-triggers when errors are encountered. |
-| verification-before-completion | Auto-triggers before Claude marks work done. Runs a verification checklist. |
-| requesting-code-review | Organises changes, writes clear PR descriptions, anticipates reviewer questions. |
-| receiving-code-review | Handles incoming review feedback constructively and systematically. |
-| subagent-driven-development | Dispatches a fresh sub-agent per task with two-stage review: spec compliance then code quality. |
-| dispatching-parallel-agents | Runs independent tasks in parallel across sub-agents for maximum throughput. |
-| using-git-worktrees | Creates isolated Git workspaces per branch, enabling parallel feature development. |
-| finishing-a-development-branch | End-of-branch workflow: final verification, PR preparation, merge-back steps. |
-| executing-plans | Executes implementation plans in batches with human checkpoints between phases. |
-| writing-skills | General technical writing quality skill. Auto-triggers when producing reports, specs, or docs. |
-| using-superpowers | Bootstraps the full Superpowers methodology. Teaches Claude the brainstorm-plan-implement loop. |
+| Skill | Description | Trigger | When to use |
+|-------|-------------|---------|-------------|
+| brainstorming | Refines rough ideas through structured Q&A, explores alternatives, presents design in sections for validation. | `/brainstorming` | Before starting any new feature or design decision |
+| writing-plans | Breaks approved designs into 2-5 minute tasks with exact file paths, complete code, and verification steps. | `/writing-plans` | After brainstorming, before writing any code |
+| test-driven-development | Enforces RED-GREEN-REFACTOR. Write failing test, watch it fail, write minimal code, commit. | `auto` on new code | When implementing any testable feature or function |
+| systematic-debugging | Hypothesis-driven root cause analysis. Auto-triggers when errors are encountered. | `auto` on errors | When an error or unexpected behaviour is encountered |
+| verification-before-completion | Auto-triggers before Claude marks work done. Runs a verification checklist. | `auto` before done | Before marking any task complete |
+| requesting-code-review | Organises changes, writes clear PR descriptions, anticipates reviewer questions. | `/requesting-code-review` | When preparing a PR or seeking peer review |
+| receiving-code-review | Handles incoming review feedback constructively and systematically. | `/receiving-code-review` | When processing reviewer comments on your PR |
+| subagent-driven-development | Dispatches a fresh sub-agent per task with two-stage review: spec compliance then code quality. | `/subagent-driven-development` | When running complex multi-step tasks with quality gates |
+| dispatching-parallel-agents | Runs independent tasks in parallel across sub-agents for maximum throughput. | `/dispatching-parallel-agents` | When multiple independent tasks can run concurrently |
+| using-git-worktrees | Creates isolated Git workspaces per branch, enabling parallel feature development. | `/using-git-worktrees` | When working on multiple features simultaneously |
+| finishing-a-development-branch | End-of-branch workflow: final verification, PR preparation, merge-back steps. | `/finishing-a-development-branch` | When a feature branch is ready to ship |
+| executing-plans | Executes implementation plans in batches with human checkpoints between phases. | `/executing-plans` | When running a multi-phase implementation plan |
+| writing-skills | General technical writing quality skill. Auto-triggers when producing reports, specs, or docs. | `auto` on docs | When producing reports, specifications, or documentation |
+| using-superpowers | Bootstraps the full Superpowers methodology. Teaches Claude the brainstorm-plan-implement loop. | `/using-superpowers` | When onboarding to the Superpowers workflow for the first time |
 
 **Install all at once (via plugin):**
 ```
@@ -49,28 +49,28 @@ npx skills@latest add obra/superpowers --skill using-superpowers -y```
 
 ## Planning & Product — mattpocock/skills
 
-| Skill | Install | Description |
-|-------|---------|-------------|
-| grill-me | `npx skills@latest add mattpocock/skills --skill grill-me -y` | Relentlessly interviews you about a plan until every decision branch is resolved. |
-| write-a-prd | `npx skills@latest add mattpocock/skills --skill write-a-prd -y` | Creates a PRD through interactive interview, codebase exploration, and module design. |
-| prd-to-plan | `npx skills@latest add mattpocock/skills --skill prd-to-plan -y` | Converts a PRD into a multi-phase implementation plan using tracer-bullet vertical slices. |
-| prd-to-issues | `npx skills@latest add mattpocock/skills --skill prd-to-issues -y` | Breaks a PRD into independently-grabbable GitHub issues using vertical slices. |
-| request-refactor-plan | `npx skills@latest add mattpocock/skills --skill request-refactor-plan -y` | Creates a detailed refactor plan with tiny commits via user interview. |
-| design-an-interface | `npx skills@latest add mattpocock/skills --skill design-an-interface -y` | Generates multiple radically different interface designs using parallel sub-agents. |
-| tdd | `npx skills@latest add mattpocock/skills --skill tdd -y` | TypeScript-focused TDD workflow with opinionated patterns and strict RED-GREEN-REFACTOR. |
-| setup-pre-commit | `npx skills@latest add mattpocock/skills --skill setup-pre-commit -y` | Sets up pre-commit hooks with lint, type-check, and test runs. |
-| git-guardrails-claude-code | `npx skills@latest add mattpocock/skills --skill git-guardrails-claude-code -y` | Installs hooks to block dangerous git commands: push, reset --hard, clean. |
-| write-a-skill | `npx skills@latest add mattpocock/skills --skill write-a-skill -y` | Opinionated skill authoring workflow with bundled resource patterns. |
-| ubiquitous-language | `npx skills@latest add mattpocock/skills --skill ubiquitous-language -y` | Extracts a DDD-style ubiquitous language glossary from the current conversation. |
-| obsidian-vault | `npx skills@latest add mattpocock/skills --skill obsidian-vault -y` | Search, create, and manage notes in an Obsidian vault with wikilinks. |
-| scaffold-exercises | `npx skills@latest add mattpocock/skills --skill scaffold-exercises -y` | Scaffolds coding exercises with solutions and test suites. |
+| Skill | Install | Description | Trigger | When to use |
+|-------|---------|-------------|---------|-------------|
+| grill-me | `npx skills@latest add mattpocock/skills --skill grill-me -y` | Relentlessly interviews you about a plan until every decision branch is resolved. | `/grill-me` | When a plan has ambiguous assumptions that need surfacing |
+| write-a-prd | `npx skills@latest add mattpocock/skills --skill write-a-prd -y` | Creates a PRD through interactive interview, codebase exploration, and module design. | `/write-a-prd` | When starting a new feature and need a structured requirements doc |
+| prd-to-plan | `npx skills@latest add mattpocock/skills --skill prd-to-plan -y` | Converts a PRD into a multi-phase implementation plan using tracer-bullet vertical slices. | `/prd-to-plan` | After writing a PRD and ready to break it into phases |
+| prd-to-issues | `npx skills@latest add mattpocock/skills --skill prd-to-issues -y` | Breaks a PRD into independently-grabbable GitHub issues using vertical slices. | `/prd-to-issues` | When decomposing a PRD into trackable GitHub issues |
+| request-refactor-plan | `npx skills@latest add mattpocock/skills --skill request-refactor-plan -y` | Creates a detailed refactor plan with tiny commits via user interview. | `/request-refactor-plan` | Before refactoring complex or risky code sections |
+| design-an-interface | `npx skills@latest add mattpocock/skills --skill design-an-interface -y` | Generates multiple radically different interface designs using parallel sub-agents. | `/design-an-interface` | When exploring multiple design directions in parallel |
+| tdd | `npx skills@latest add mattpocock/skills --skill tdd -y` | TypeScript-focused TDD workflow with opinionated patterns and strict RED-GREEN-REFACTOR. | `/tdd` | When writing TypeScript with strict TDD discipline |
+| setup-pre-commit | `npx skills@latest add mattpocock/skills --skill setup-pre-commit -y` | Sets up pre-commit hooks with lint, type-check, and test runs. | `/setup-pre-commit` | When initializing a new project's quality gates |
+| git-guardrails-claude-code | `npx skills@latest add mattpocock/skills --skill git-guardrails-claude-code -y` | Installs hooks to block dangerous git commands: push, reset --hard, clean. | `/git-guardrails-claude-code` | When setting up safety nets against destructive git ops |
+| write-a-skill | `npx skills@latest add mattpocock/skills --skill write-a-skill -y` | Opinionated skill authoring workflow with bundled resource patterns. | `/write-a-skill` | When authoring a new Claude skill from scratch |
+| ubiquitous-language | `npx skills@latest add mattpocock/skills --skill ubiquitous-language -y` | Extracts a DDD-style ubiquitous language glossary from the current conversation. | `/ubiquitous-language` | When aligning team on domain terminology from a design discussion |
+| obsidian-vault | `npx skills@latest add mattpocock/skills --skill obsidian-vault -y` | Search, create, and manage notes in an Obsidian vault with wikilinks. | `/obsidian-vault` | When storing or retrieving project notes in Obsidian |
+| scaffold-exercises | `npx skills@latest add mattpocock/skills --skill scaffold-exercises -y` | Scaffolds coding exercises with solutions and test suites. | `/scaffold-exercises` | When creating coding exercises with automated test validation |
 
 ---
 
 ## GitHub — github/awesome-copilot
 
-| Skill | Install | Description |
-|-------|---------|-------------|
-| git-commit | `npx skills@latest add github/awesome-copilot --skill git-commit -y` | Generates conventional commit messages from staged diff with scope detection. |
-| gh-cli | `npx skills@latest add github/awesome-copilot --skill gh-cli -y` | Automates GitHub CLI workflows: PR creation, issue management, release drafts. |
-| prd | `npx skills@latest add github/awesome-copilot --skill prd -y` | GitHub Copilot's PRD workflow for turning specs into tracked GitHub issues. |
+| Skill | Install | Description | Trigger | When to use |
+|-------|---------|-------------|---------|-------------|
+| git-commit | `npx skills@latest add github/awesome-copilot --skill git-commit -y` | Generates conventional commit messages from staged diff with scope detection. | `/git-commit` | Before every commit to generate a well-structured message |
+| gh-cli | `npx skills@latest add github/awesome-copilot --skill gh-cli -y` | Automates GitHub CLI workflows: PR creation, issue management, release drafts. | `/gh-cli` | When managing PRs, issues, or releases via GitHub CLI |
+| prd | `npx skills@latest add github/awesome-copilot --skill prd -y` | GitHub Copilot's PRD workflow for turning specs into tracked GitHub issues. | `/prd` | When converting a spec into tracked GitHub issues |

--- a/power-engineer/references/catalog/docs-research.md
+++ b/power-engineer/references/catalog/docs-research.md
@@ -2,31 +2,31 @@
 
 ## Document Generation — Anthropic Official
 
-| Skill | Install | Description |
-|-------|---------|-------------|
-| docx | `npx skills@latest add anthropics/skills --skill docx -y` | Creates and edits Word documents with headers, tables, tracked changes. |
-| pptx | `npx skills@latest add anthropics/skills --skill pptx -y` | Builds polished PowerPoint presentations with layouts, speaker notes, themes. |
-| xlsx | `npx skills@latest add anthropics/skills --skill xlsx -y` | Creates and manipulates Excel spreadsheets with formulas, pivot tables. |
-| pdf | `npx skills@latest add anthropics/skills --skill pdf -y` | PDF manipulation: text extraction, merging, splitting, form filling, OCR. |
-| internal-comms | `npx skills@latest add anthropics/skills --skill internal-comms -y` | Internal communications: status reports, newsletters, FAQs. |
+| Skill | Install | Description | Trigger | When to use |
+|-------|---------|-------------|---------|-------------|
+| docx | `npx skills@latest add anthropics/skills --skill docx -y` | Creates and edits Word documents with headers, tables, tracked changes. | `/docx` | When generating or editing Word documents programmatically |
+| pptx | `npx skills@latest add anthropics/skills --skill pptx -y` | Builds polished PowerPoint presentations with layouts, speaker notes, themes. | `/pptx` | When generating presentation slides from content or data |
+| xlsx | `npx skills@latest add anthropics/skills --skill xlsx -y` | Creates and manipulates Excel spreadsheets with formulas, pivot tables. | `/xlsx` | When generating or transforming Excel spreadsheets |
+| pdf | `npx skills@latest add anthropics/skills --skill pdf -y` | PDF manipulation: text extraction, merging, splitting, form filling, OCR. | `/pdf` | When reading, merging, splitting, or filling PDF documents |
+| internal-comms | `npx skills@latest add anthropics/skills --skill internal-comms -y` | Internal communications: status reports, newsletters, FAQs. | `/internal-comms` | When drafting status reports, newsletters, or internal FAQs |
 
 ---
 
 ## Technical Writing — supercent-io/skills-template
 
-| Skill | Install | Description |
-|-------|---------|-------------|
-| technical-writing | `npx skills@latest add supercent-io/skills-template --skill technical-writing -y` | Docs standards: clarity, structure, audience targeting, doc testing. |
-| api-documentation | `npx skills@latest add supercent-io/skills-template --skill api-documentation -y` | OpenAPI/Swagger-aligned API docs with examples and error catalogs. |
-| user-guide-writing | `npx skills@latest add supercent-io/skills-template --skill user-guide-writing -y` | End-user documentation: step-by-step instructions, visual aids. |
+| Skill | Install | Description | Trigger | When to use |
+|-------|---------|-------------|---------|-------------|
+| technical-writing | `npx skills@latest add supercent-io/skills-template --skill technical-writing -y` | Docs standards: clarity, structure, audience targeting, doc testing. | `/technical-writing` | When writing or auditing technical documentation for clarity and structure |
+| api-documentation | `npx skills@latest add supercent-io/skills-template --skill api-documentation -y` | OpenAPI/Swagger-aligned API docs with examples and error catalogs. | `/api-documentation` | When writing or updating OpenAPI-aligned API reference documentation |
+| user-guide-writing | `npx skills@latest add supercent-io/skills-template --skill user-guide-writing -y` | End-user documentation: step-by-step instructions, visual aids. | `/user-guide-writing` | When writing end-user guides with step-by-step instructions |
 
 ---
 
 ## Web Research & Data
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| firecrawl | firecrawl/cli | `npx skills@latest add firecrawl/cli --skill firecrawl -y` | Web crawl and structure data from any URL for research and RAG. |
-| search | tavily-ai/skills | `npx skills@latest add tavily-ai/skills --skill search -y` | Tavily real-time search with structured result extraction. |
-| data-analysis | supercent-io | `npx skills@latest add supercent-io/skills-template --skill data-analysis -y` | Data exploration, statistical analysis, and visualisation in Python/R. |
-| browser-use | browser-use | `npx skills@latest add browser-use/browser-use --skill browser-use -y` | Browser automation: navigation, form filling, extraction, screenshot. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| firecrawl | firecrawl/cli | `npx skills@latest add firecrawl/cli --skill firecrawl -y` | Web crawl and structure data from any URL for research and RAG. | `/firecrawl` | When crawling websites to extract structured data for research or RAG |
+| search | tavily-ai/skills | `npx skills@latest add tavily-ai/skills --skill search -y` | Tavily real-time search with structured result extraction. | `/search` | When grounding AI responses with real-time web search results |
+| data-analysis | supercent-io | `npx skills@latest add supercent-io/skills-template --skill data-analysis -y` | Data exploration, statistical analysis, and visualisation in Python/R. | `/data-analysis` | When exploring datasets or building statistical visualisations |
+| browser-use | browser-use | `npx skills@latest add browser-use/browser-use --skill browser-use -y` | Browser automation: navigation, form filling, extraction, screenshot. | `/browser-use` | When automating browser navigation, form filling, or content extraction |

--- a/power-engineer/references/catalog/engineering/agentic-ai.md
+++ b/power-engineer/references/catalog/engineering/agentic-ai.md
@@ -2,37 +2,37 @@
 
 ## AI/LLM SDKs — inferen-sh/skills
 
-| Skill | Scope | Install | Description |
-|-------|-------|---------|-------------|
-| python-sdk | `local` | `npx skills@latest add inferen-sh/skills --skill python-sdk -y` | Anthropic Python SDK: async usage, streaming, tool use, batch processing. |
-| javascript-sdk | `local` | `npx skills@latest add inferen-sh/skills --skill javascript-sdk -y` | Anthropic JS/TS SDK: client setup, error handling, token management, streaming. |
-| chat-ui | `local` | `npx skills@latest add inferen-sh/skills --skill chat-ui -y` | Production chat UI: streaming responses, message history, tool call rendering. |
-| agent-ui | `local` | `npx skills@latest add inferen-sh/skills --skill agent-ui -y` | Agent-specific UI: tool use visualisation, step tracking, human approval flows. |
-| tools-ui | `local` | `npx skills@latest add inferen-sh/skills --skill tools-ui -y` | UI patterns for rendering tool calls, results, and intermediate agent steps. |
-| widgets-ui | `local` | `npx skills@latest add inferen-sh/skills --skill widgets-ui -y` | Embeddable widget patterns for AI-powered components within larger apps. |
-| web-search | `local` | `npx skills@latest add inferen-sh/skills --skill web-search -y` | Structured web search integration for grounding AI responses in current information. |
-| python-executor | `local` | `npx skills@latest add inferen-sh/skills --skill python-executor -y` | Safe Python code execution within agent sessions for data processing. |
-| agent-browser | `local` | `npx skills@latest add inferen-sh/skills --skill agent-browser -y` | Browser automation from within agent sessions: navigation, extraction, interaction. |
-| ai-image-generation | `local` | `npx skills@latest add inferen-sh/skills --skill ai-image-generation -y` | AI image generation: prompt engineering, model selection, output handling. |
-| elevenlabs-tts | `local` | `npx skills@latest add inferen-sh/skills --skill elevenlabs-tts -y` | ElevenLabs text-to-speech: voice selection, streaming audio, multilingual. |
-| elevenlabs-music | `local` | `npx skills@latest add inferen-sh/skills --skill elevenlabs-music -y` | ElevenLabs music generation: sound effects, background scores, audio export. |
+| Skill | Scope | Install | Description | Trigger | When to use |
+|-------|-------|---------|-------------|---------|-------------|
+| python-sdk | `local` | `npx skills@latest add inferen-sh/skills --skill python-sdk -y` | Anthropic Python SDK: async usage, streaming, tool use, batch processing. | `/python-sdk` | When building Python apps with the Anthropic SDK |
+| javascript-sdk | `local` | `npx skills@latest add inferen-sh/skills --skill javascript-sdk -y` | Anthropic JS/TS SDK: client setup, error handling, token management, streaming. | `/javascript-sdk` | When integrating the Anthropic JS/TS SDK into a web or Node app |
+| chat-ui | `local` | `npx skills@latest add inferen-sh/skills --skill chat-ui -y` | Production chat UI: streaming responses, message history, tool call rendering. | `/chat-ui` | When building a streaming chat interface with message history |
+| agent-ui | `local` | `npx skills@latest add inferen-sh/skills --skill agent-ui -y` | Agent-specific UI: tool use visualisation, step tracking, human approval flows. | `/agent-ui` | When building UIs that display agent steps and tool call results |
+| tools-ui | `local` | `npx skills@latest add inferen-sh/skills --skill tools-ui -y` | UI patterns for rendering tool calls, results, and intermediate agent steps. | `/tools-ui` | When displaying tool calls and intermediate agent outputs in the UI |
+| widgets-ui | `local` | `npx skills@latest add inferen-sh/skills --skill widgets-ui -y` | Embeddable widget patterns for AI-powered components within larger apps. | `/widgets-ui` | When embedding AI-powered widgets into an existing application |
+| web-search | `local` | `npx skills@latest add inferen-sh/skills --skill web-search -y` | Structured web search integration for grounding AI responses in current information. | `/web-search` | When grounding agent responses with live web search results |
+| python-executor | `local` | `npx skills@latest add inferen-sh/skills --skill python-executor -y` | Safe Python code execution within agent sessions for data processing. | `/python-executor` | When executing Python code safely inside an agent session |
+| agent-browser | `local` | `npx skills@latest add inferen-sh/skills --skill agent-browser -y` | Browser automation from within agent sessions: navigation, extraction, interaction. | `/agent-browser` | When automating browser navigation and extraction from agent sessions |
+| ai-image-generation | `local` | `npx skills@latest add inferen-sh/skills --skill ai-image-generation -y` | AI image generation: prompt engineering, model selection, output handling. | `/ai-image-generation` | When generating images with AI models from within an agent |
+| elevenlabs-tts | `local` | `npx skills@latest add inferen-sh/skills --skill elevenlabs-tts -y` | ElevenLabs text-to-speech: voice selection, streaming audio, multilingual. | `/elevenlabs-tts` | When adding text-to-speech audio output to an agent or app |
+| elevenlabs-music | `local` | `npx skills@latest add inferen-sh/skills --skill elevenlabs-music -y` | ElevenLabs music generation: sound effects, background scores, audio export. | `/elevenlabs-music` | When generating background music or sound effects programmatically |
 
 ---
 
 ## Agentic Patterns
 
-| Skill | Source | Scope | Install | Description |
-|-------|--------|-------|---------|-------------|
-| self-improving-agent | charon-fan/agent-playbook | `local` | `npx skills@latest add charon-fan/agent-playbook --skill self-improving-agent -y` | Self-improvement loop where the agent iteratively refines its own outputs. |
-| agenthub | alirezarezvani/claude-skills | `local` | `/plugin install agenthub@claude-code-skills` | Spawns N parallel subagents competing on the same task via git worktree isolation; evaluates by metric or LLM judge; merges the best branch. |
-| autoresearch-agent | alirezarezvani/claude-skills | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Autonomous experiment loop that optimizes any file by a measurable metric. Edits, evaluates, keeps improvements, discards failures, loops indefinitely (Karpathy-inspired). |
-| agent-designer | alirezarezvani/claude-skills | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Multi-agent system architecture patterns, tool design principles, communication strategies, performance evaluation frameworks. |
+| Skill | Source | Scope | Install | Description | Trigger | When to use |
+|-------|--------|-------|---------|-------------|---------|-------------|
+| self-improving-agent | charon-fan/agent-playbook | `local` | `npx skills@latest add charon-fan/agent-playbook --skill self-improving-agent -y` | Self-improvement loop where the agent iteratively refines its own outputs. | `/self-improving-agent` | When iteratively refining an agent's outputs through self-evaluation loops |
+| agenthub | alirezarezvani/claude-skills | `local` | `/plugin install agenthub@claude-code-skills` | Spawns N parallel subagents competing on the same task via git worktree isolation; evaluates by metric or LLM judge; merges the best branch. | `/agenthub` | When running parallel competing agents to find the best solution |
+| autoresearch-agent | alirezarezvani/claude-skills | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Autonomous experiment loop that optimizes any file by a measurable metric. Edits, evaluates, keeps improvements, discards failures, loops indefinitely (Karpathy-inspired). | `/autoresearch-agent` | When autonomously optimising a file or model by a measurable metric |
+| agent-designer | alirezarezvani/claude-skills | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Multi-agent system architecture patterns, tool design principles, communication strategies, performance evaluation frameworks. | `/agent-designer` | When architecting multi-agent systems with evaluation frameworks |
 
 ---
 
 ## Vercel AI SDK
 
-| Skill | Source | Scope | Install | Description |
-|-------|--------|-------|---------|-------------|
-| ai-sdk | vercel/ai | `local` | `npx skills@latest add vercel/ai --skill ai-sdk -y` | Vercel AI SDK: streaming, tool calling, multi-step agents, model switching, edge deployment. |
-| agent-browser | vercel-labs | `local` | `npx skills@latest add vercel-labs/agent-browser --skill agent-browser -y` | Vercel browser agent: navigates, interacts with, and extracts content from live websites. |
+| Skill | Source | Scope | Install | Description | Trigger | When to use |
+|-------|--------|-------|---------|-------------|---------|-------------|
+| ai-sdk | vercel/ai | `local` | `npx skills@latest add vercel/ai --skill ai-sdk -y` | Vercel AI SDK: streaming, tool calling, multi-step agents, model switching, edge deployment. | `/ai-sdk` | When building streaming AI features with Vercel AI SDK |
+| agent-browser | vercel-labs | `local` | `npx skills@latest add vercel-labs/agent-browser --skill agent-browser -y` | Vercel browser agent: navigates, interacts with, and extracts content from live websites. | `/agent-browser` | When navigating and extracting content from websites via Vercel agent |

--- a/power-engineer/references/catalog/engineering/backend-architecture.md
+++ b/power-engineer/references/catalog/engineering/backend-architecture.md
@@ -2,38 +2,38 @@
 
 ## Architecture & Backend — wshobson/agents
 
-| Skill | Install | Description |
-|-------|---------|-------------|
-| api-design-principles | `npx skills@latest add wshobson/agents --skill api-design-principles -y` | REST API design: naming, versioning, error handling, response shaping, hypermedia. |
-| typescript-advanced-types | `npx skills@latest add wshobson/agents --skill typescript-advanced-types -y` | Advanced TypeScript: conditional types, mapped types, template literals, type-level programming. |
-| nodejs-backend-patterns | `npx skills@latest add wshobson/agents --skill nodejs-backend-patterns -y` | Production Node.js: middleware, error handling, DI, module structure. |
-| python-performance-optimization | `npx skills@latest add wshobson/agents --skill python-performance-optimization -y` | Python profiling, vectorisation, memory management, async patterns. |
-| tailwind-design-system | `npx skills@latest add wshobson/agents --skill tailwind-design-system -y` | Tailwind design system: tokens, variants, responsive utilities, component APIs. |
+| Skill | Install | Description | Trigger | When to use |
+|-------|---------|-------------|---------|-------------|
+| api-design-principles | `npx skills@latest add wshobson/agents --skill api-design-principles -y` | REST API design: naming, versioning, error handling, response shaping, hypermedia. | `/api-design-principles` | When designing or reviewing a REST API's structure and conventions |
+| typescript-advanced-types | `npx skills@latest add wshobson/agents --skill typescript-advanced-types -y` | Advanced TypeScript: conditional types, mapped types, template literals, type-level programming. | `/typescript-advanced-types` | When working with complex TypeScript generics or type-level logic |
+| nodejs-backend-patterns | `npx skills@latest add wshobson/agents --skill nodejs-backend-patterns -y` | Production Node.js: middleware, error handling, DI, module structure. | `/nodejs-backend-patterns` | When structuring a production Node.js service or API |
+| python-performance-optimization | `npx skills@latest add wshobson/agents --skill python-performance-optimization -y` | Python profiling, vectorisation, memory management, async patterns. | `/python-performance-optimization` | When profiling or optimising a slow Python service |
+| tailwind-design-system | `npx skills@latest add wshobson/agents --skill tailwind-design-system -y` | Tailwind design system: tokens, variants, responsive utilities, component APIs. | `/tailwind-design-system` | When building a Tailwind-based design token and component system |
 
 ---
 
 ## Engineering Templates — supercent-io/skills-template
 
-| Skill | Install | Description |
-|-------|---------|-------------|
-| database-schema-design | `npx skills@latest add supercent-io/skills-template --skill database-schema-design -y` | Relational and NoSQL schema design, normalisation, indexing, migration patterns. |
-| authentication-setup | `npx skills@latest add supercent-io/skills-template --skill authentication-setup -y` | Auth implementation: OAuth, JWT, session management, MFA patterns. |
-| api-design | `npx skills@latest add supercent-io/skills-template --skill api-design -y` | API design from first principles: consistency, discoverability, backwards compatibility. |
-| api-documentation | `npx skills@latest add supercent-io/skills-template --skill api-documentation -y` | OpenAPI/Swagger-aligned API docs with examples, error catalogs, changelog conventions. |
-| performance-optimization | `npx skills@latest add supercent-io/skills-template --skill performance-optimization -y` | Performance audit: caching, lazy loading, algorithmic complexity, bottleneck ID. |
-| monitoring-observability | `npx skills@latest add supercent-io/skills-template --skill monitoring-observability -y` | Structured logging, metrics, distributed tracing, alerting instrumentation. |
-| deployment-automation | `npx skills@latest add supercent-io/skills-template --skill deployment-automation -y` | CI/CD pipeline design, automated deployment, rollback strategies. |
-| git-workflow | `npx skills@latest add supercent-io/skills-template --skill git-workflow -y` | Git branching strategies, commit conventions, rebase vs merge policies. |
-| task-planning | `npx skills@latest add supercent-io/skills-template --skill task-planning -y` | Breaks complex features into granular, prioritised, time-estimated tasks. |
-| changelog-maintenance | `npx skills@latest add supercent-io/skills-template --skill changelog-maintenance -y` | Maintains structured changelogs following Keep a Changelog conventions. |
-| file-organization | `npx skills@latest add supercent-io/skills-template --skill file-organization -y` | Project file structure conventions and organisation strategies. |
-| log-analysis | `npx skills@latest add supercent-io/skills-template --skill log-analysis -y` | Parses and analyses log output to surface patterns, errors, and anomalies. |
-| codebase-search | `npx skills@latest add supercent-io/skills-template --skill codebase-search -y` | Strategies for navigating and understanding unfamiliar codebases quickly. |
+| Skill | Install | Description | Trigger | When to use |
+|-------|---------|-------------|---------|-------------|
+| database-schema-design | `npx skills@latest add supercent-io/skills-template --skill database-schema-design -y` | Relational and NoSQL schema design, normalisation, indexing, migration patterns. | `/database-schema-design` | When designing or reviewing a database schema from scratch |
+| authentication-setup | `npx skills@latest add supercent-io/skills-template --skill authentication-setup -y` | Auth implementation: OAuth, JWT, session management, MFA patterns. | `/authentication-setup` | When implementing authentication or reviewing auth security |
+| api-design | `npx skills@latest add supercent-io/skills-template --skill api-design -y` | API design from first principles: consistency, discoverability, backwards compatibility. | `/api-design` | When designing a new API or auditing an existing one for consistency |
+| api-documentation | `npx skills@latest add supercent-io/skills-template --skill api-documentation -y` | OpenAPI/Swagger-aligned API docs with examples, error catalogs, changelog conventions. | `/api-documentation` | When writing or updating OpenAPI/Swagger API documentation |
+| performance-optimization | `npx skills@latest add supercent-io/skills-template --skill performance-optimization -y` | Performance audit: caching, lazy loading, algorithmic complexity, bottleneck ID. | `/performance-optimization` | When diagnosing and fixing performance bottlenecks |
+| monitoring-observability | `npx skills@latest add supercent-io/skills-template --skill monitoring-observability -y` | Structured logging, metrics, distributed tracing, alerting instrumentation. | `/monitoring-observability` | When adding observability, logging, or metrics to a service |
+| deployment-automation | `npx skills@latest add supercent-io/skills-template --skill deployment-automation -y` | CI/CD pipeline design, automated deployment, rollback strategies. | `/deployment-automation` | When setting up or improving a CI/CD deployment pipeline |
+| git-workflow | `npx skills@latest add supercent-io/skills-template --skill git-workflow -y` | Git branching strategies, commit conventions, rebase vs merge policies. | `/git-workflow` | When establishing or improving a team's Git branching strategy |
+| task-planning | `npx skills@latest add supercent-io/skills-template --skill task-planning -y` | Breaks complex features into granular, prioritised, time-estimated tasks. | `/task-planning` | When decomposing a complex feature into granular actionable tasks |
+| changelog-maintenance | `npx skills@latest add supercent-io/skills-template --skill changelog-maintenance -y` | Maintains structured changelogs following Keep a Changelog conventions. | `/changelog-maintenance` | When updating the project changelog before a release |
+| file-organization | `npx skills@latest add supercent-io/skills-template --skill file-organization -y` | Project file structure conventions and organisation strategies. | `/file-organization` | When structuring a new project or reorganising an existing codebase |
+| log-analysis | `npx skills@latest add supercent-io/skills-template --skill log-analysis -y` | Parses and analyses log output to surface patterns, errors, and anomalies. | `/log-analysis` | When investigating error patterns or anomalies in service logs |
+| codebase-search | `npx skills@latest add supercent-io/skills-template --skill codebase-search -y` | Strategies for navigating and understanding unfamiliar codebases quickly. | `/codebase-search` | When onboarding to or navigating an unfamiliar codebase |
 
 ---
 
 ## Payments — alirezarezvani/claude-skills
 
-| Skill | Install | Description |
-|-------|---------|-------------|
-| stripe-integration-expert | `/plugin install stripe-integration-expert@claude-code-skills` | Stripe payment integration: webhooks, subscription billing, checkout flows, error handling. |
+| Skill | Install | Description | Trigger | When to use |
+|-------|---------|-------------|---------|-------------|
+| stripe-integration-expert | `/plugin install stripe-integration-expert@claude-code-skills` | Stripe payment integration: webhooks, subscription billing, checkout flows, error handling. | `/stripe-integration-expert` | When implementing Stripe payments, webhooks, or subscription billing |

--- a/power-engineer/references/catalog/engineering/data-ml.md
+++ b/power-engineer/references/catalog/engineering/data-ml.md
@@ -2,40 +2,40 @@
 
 ## Data Engineering — alirezarezvani/claude-skills
 
-| Skill | Install | Description |
-|-------|---------|-------------|
-| senior-data-engineer | `/plugin install engineering-advanced-skills@claude-code-skills` | Data pipelines, ETL/ELT, Spark, Airflow, dbt, Kafka, data quality frameworks, DataOps practices. |
+| Skill | Install | Description | Trigger | When to use |
+|-------|---------|-------------|---------|-------------|
+| senior-data-engineer | `/plugin install engineering-advanced-skills@claude-code-skills` | Data pipelines, ETL/ELT, Spark, Airflow, dbt, Kafka, data quality frameworks, DataOps practices. | `/senior-data-engineer` | When building or reviewing data pipelines, ETL/ELT, or DataOps workflows |
 
 ---
 
 ## Data Science — alirezarezvani/claude-skills
 
-| Skill | Install | Description |
-|-------|---------|-------------|
-| senior-data-scientist | `/plugin install engineering-advanced-skills@claude-code-skills` | Statistical modeling, A/B testing, causal inference, SHAP explainability, MLflow experiment tracking. |
+| Skill | Install | Description | Trigger | When to use |
+|-------|---------|-------------|---------|-------------|
+| senior-data-scientist | `/plugin install engineering-advanced-skills@claude-code-skills` | Statistical modeling, A/B testing, causal inference, SHAP explainability, MLflow experiment tracking. | `/senior-data-scientist` | When running A/B tests, statistical models, or ML experiment tracking |
 
 ---
 
 ## Machine Learning & MLOps — alirezarezvani/claude-skills
 
-| Skill | Install | Description |
-|-------|---------|-------------|
-| senior-ml-engineer | `/plugin install engineering-advanced-skills@claude-code-skills` | Model deployment, MLOps (MLflow, Kubeflow), drift monitoring, model serving, automated retraining, RAG systems. |
-| senior-computer-vision | `/plugin install engineering-advanced-skills@claude-code-skills` | Object detection, segmentation, YOLO/DETR/SAM, ONNX/TensorRT deployment, video processing. |
+| Skill | Install | Description | Trigger | When to use |
+|-------|---------|-------------|---------|-------------|
+| senior-ml-engineer | `/plugin install engineering-advanced-skills@claude-code-skills` | Model deployment, MLOps (MLflow, Kubeflow), drift monitoring, model serving, automated retraining, RAG systems. | `/senior-ml-engineer` | When deploying ML models, setting up MLOps, or building RAG systems |
+| senior-computer-vision | `/plugin install engineering-advanced-skills@claude-code-skills` | Object detection, segmentation, YOLO/DETR/SAM, ONNX/TensorRT deployment, video processing. | `/senior-computer-vision` | When building object detection, segmentation, or video analysis pipelines |
 
 ---
 
 ## Data Analysis — supercent-io/skills-template
 
-| Skill | Install | Description |
-|-------|---------|-------------|
-| data-analysis | `npx skills@latest add supercent-io/skills-template --skill data-analysis -y` | Data exploration, statistical analysis, and visualisation patterns in Python/R. |
+| Skill | Install | Description | Trigger | When to use |
+|-------|---------|-------------|---------|-------------|
+| data-analysis | `npx skills@latest add supercent-io/skills-template --skill data-analysis -y` | Data exploration, statistical analysis, and visualisation patterns in Python/R. | `/data-analysis` | When exploring datasets, running statistical analysis, or building charts |
 
 ---
 
 ## Data & Research Tools
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| firecrawl | firecrawl/cli | `npx skills@latest add firecrawl/cli --skill firecrawl -y` | Web crawl and structure data from any URL for research pipelines and RAG. |
-| search | tavily-ai/skills | `npx skills@latest add tavily-ai/skills --skill search -y` | Tavily real-time search with structured result extraction for AI-grounded research. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| firecrawl | firecrawl/cli | `npx skills@latest add firecrawl/cli --skill firecrawl -y` | Web crawl and structure data from any URL for research pipelines and RAG. | `/firecrawl` | When crawling websites to extract structured data for research or RAG |
+| search | tavily-ai/skills | `npx skills@latest add tavily-ai/skills --skill search -y` | Tavily real-time search with structured result extraction for AI-grounded research. | `/search` | When grounding AI responses with real-time web search results |

--- a/power-engineer/references/catalog/engineering/devops-infra.md
+++ b/power-engineer/references/catalog/engineering/devops-infra.md
@@ -2,32 +2,32 @@
 
 ## Containers & Orchestration — alirezarezvani/claude-skills
 
-| Skill | Scope | Install | Description |
-|-------|-------|---------|-------------|
-| docker-development | `local` | `/plugin install engineering-skills@claude-code-skills` | Dockerfile optimization, multi-stage builds, layer caching, docker-compose orchestration, container security hardening. |
-| helm-chart-builder | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Helm chart scaffolding, values design, template helpers, subchart management, RBAC, network policies, pod security. |
+| Skill | Scope | Install | Description | Trigger | When to use |
+|-------|-------|---------|-------------|---------|-------------|
+| docker-development | `local` | `/plugin install engineering-skills@claude-code-skills` | Dockerfile optimization, multi-stage builds, layer caching, docker-compose orchestration, container security hardening. | `/docker-development` | When writing or optimising Dockerfiles and compose configs |
+| helm-chart-builder | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Helm chart scaffolding, values design, template helpers, subchart management, RBAC, network policies, pod security. | `/helm-chart-builder` | When creating or maintaining Helm charts for Kubernetes deployments |
 
 ---
 
 ## Infrastructure as Code — alirezarezvani/claude-skills
 
-| Skill | Scope | Install | Description |
-|-------|-------|---------|-------------|
-| terraform-patterns | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Terraform module design, state management, multi-region deployments, security hardening, policy-as-code with Sentinel/OPA. |
+| Skill | Scope | Install | Description | Trigger | When to use |
+|-------|-------|---------|-------------|---------|-------------|
+| terraform-patterns | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Terraform module design, state management, multi-region deployments, security hardening, policy-as-code with Sentinel/OPA. | `/terraform-patterns` | When designing or hardening Terraform infrastructure modules |
 
 ---
 
 ## Migrations & Operations — alirezarezvani/claude-skills
 
-| Skill | Scope | Install | Description |
-|-------|-------|---------|-------------|
-| migration-architect | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Zero-downtime migration planning, compatibility validation, rollback strategy generation for systems, databases, and infrastructure. |
-| runbook-generator | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Generates operational runbooks for SRE/DevOps incident response and routine operations. |
+| Skill | Scope | Install | Description | Trigger | When to use |
+|-------|-------|---------|-------------|---------|-------------|
+| migration-architect | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Zero-downtime migration planning, compatibility validation, rollback strategy generation for systems, databases, and infrastructure. | `/migration-architect` | When planning a zero-downtime system, database, or infra migration |
+| runbook-generator | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Generates operational runbooks for SRE/DevOps incident response and routine operations. | `/runbook-generator` | When creating SRE runbooks for incident response or operations |
 
 ---
 
 ## CI/CD & Deployment — supercent-io/skills-template
 
-| Skill | Scope | Install | Description |
-|-------|-------|---------|-------------|
-| deployment-automation | `local` | `npx skills@latest add supercent-io/skills-template --skill deployment-automation -y` | CI/CD pipeline design, automated deployment, rollback strategies. |
+| Skill | Scope | Install | Description | Trigger | When to use |
+|-------|-------|---------|-------------|---------|-------------|
+| deployment-automation | `local` | `npx skills@latest add supercent-io/skills-template --skill deployment-automation -y` | CI/CD pipeline design, automated deployment, rollback strategies. | `/deployment-automation` | When designing automated deployment pipelines with rollback support |

--- a/power-engineer/references/catalog/engineering/security-ops.md
+++ b/power-engineer/references/catalog/engineering/security-ops.md
@@ -2,161 +2,161 @@
 
 ## Security Code Review
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| security-review | getsentry/skills | `npx skills@latest add getsentry/skills --skill security-review -y` | **[TOP PICK]** Confidence-based severity (HIGH/MEDIUM/LOW), data-flow tracing, low false positives. Independently rated #1 security review skill. |
-| claude-code-owasp | agamm/claude-code-owasp | `npx skills@latest add agamm/claude-code-owasp -y` | OWASP Top 10:2025, ASVS 5.0, Agentic AI security (ASI01-ASI10), 20+ language support. |
-| security-review | affaan-m/everything-claude-code | `npx skills@latest add affaan-m/everything-claude-code --skill security-review -y` | Auth, user input, secrets, API endpoints, payment features checklist. |
-| security-review-skill | MCKRUZ/security-review-skill | `npx skills@latest add MCKRUZ/security-review-skill -y` | Auth, secrets, input validation, API endpoints checklist. |
-| differential-review | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill differential-review -y` | Security-focused diff review with git history analysis. |
-| fp-check | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill fp-check -y` | Systematic false positive verification for security findings. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| security-review | getsentry/skills | `npx skills@latest add getsentry/skills --skill security-review -y` | **[TOP PICK]** Confidence-based severity (HIGH/MEDIUM/LOW), data-flow tracing, low false positives. Independently rated #1 security review skill. | `/security-review` | When performing a high-confidence security review on any codebase |
+| claude-code-owasp | agamm/claude-code-owasp | `npx skills@latest add agamm/claude-code-owasp -y` | OWASP Top 10:2025, ASVS 5.0, Agentic AI security (ASI01-ASI10), 20+ language support. | `/claude-code-owasp` | When auditing against OWASP Top 10 and Agentic AI security standards |
+| security-review | affaan-m/everything-claude-code | `npx skills@latest add affaan-m/everything-claude-code --skill security-review -y` | Auth, user input, secrets, API endpoints, payment features checklist. | `/security-review` | When doing a checklist-driven security review of auth and inputs |
+| security-review-skill | MCKRUZ/security-review-skill | `npx skills@latest add MCKRUZ/security-review-skill -y` | Auth, secrets, input validation, API endpoints checklist. | `/security-review-skill` | When auditing auth, secrets, and API endpoint security posture |
+| differential-review | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill differential-review -y` | Security-focused diff review with git history analysis. | `/differential-review` | When reviewing a security-sensitive diff against git history |
+| fp-check | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill fp-check -y` | Systematic false positive verification for security findings. | `/fp-check` | When verifying whether a security finding is a false positive |
 
 ---
 
 ## SAST (Static Analysis)
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| semgrep-rule-creator | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill semgrep-rule-creator -y` | Create custom Semgrep rules for vulnerability detection. |
-| semgrep-rule-variant-creator | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill semgrep-rule-variant-creator -y` | Port Semgrep rules to new languages with test-driven validation. |
-| static-analysis | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill static-analysis -y` | Static analysis toolkit with CodeQL, Semgrep, and SARIF parsing. |
-| variant-analysis | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill variant-analysis -y` | Find similar vulnerabilities across codebases using pattern analysis. |
-| codeql | github/awesome-copilot | `npx skills@latest add github/awesome-copilot --skill codeql -y` | Comprehensive CodeQL code scanning via GitHub Actions and CLI. |
-| sast-configuration | sickn33/antigravity-awesome-skills | `npx skills@latest add sickn33/antigravity-awesome-skills --skill sast-configuration -y` | SAST tool setup for Semgrep/SonarQube/CodeQL. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| semgrep-rule-creator | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill semgrep-rule-creator -y` | Create custom Semgrep rules for vulnerability detection. | `/semgrep-rule-creator` | When writing custom Semgrep detection rules for specific vulnerabilities |
+| semgrep-rule-variant-creator | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill semgrep-rule-variant-creator -y` | Port Semgrep rules to new languages with test-driven validation. | `/semgrep-rule-variant-creator` | When porting existing Semgrep rules to a new language |
+| static-analysis | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill static-analysis -y` | Static analysis toolkit with CodeQL, Semgrep, and SARIF parsing. | `/static-analysis` | When running static analysis with CodeQL, Semgrep, or parsing SARIF |
+| variant-analysis | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill variant-analysis -y` | Find similar vulnerabilities across codebases using pattern analysis. | `/variant-analysis` | When finding variants of a known vulnerability across a codebase |
+| codeql | github/awesome-copilot | `npx skills@latest add github/awesome-copilot --skill codeql -y` | Comprehensive CodeQL code scanning via GitHub Actions and CLI. | `/codeql` | When running CodeQL scans via GitHub Actions or CLI |
+| sast-configuration | sickn33/antigravity-awesome-skills | `npx skills@latest add sickn33/antigravity-awesome-skills --skill sast-configuration -y` | SAST tool setup for Semgrep/SonarQube/CodeQL. | `/sast-configuration` | When configuring SAST tooling for a new project |
 
 ---
 
 ## DAST (Dynamic Analysis)
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| dast-nuclei | majiayu000/claude-skill-registry | `npx skills@latest add majiayu000/claude-skill-registry --skill dast-nuclei -y` | DAST scanning with Nuclei templates, CVE detection, OWASP testing. |
-| nuclei-scanner | TerminalSkills/skills | `npx skills@latest add TerminalSkills/skills --skill nuclei-scanner -y` | Vulnerability scanning with Nuclei, CVE detection. |
-| ffuf-claude-skill | jthack/ffuf_claude_skill | `npx skills@latest add jthack/ffuf_claude_skill -y` | FFUF web fuzzing and reconnaissance. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| dast-nuclei | majiayu000/claude-skill-registry | `npx skills@latest add majiayu000/claude-skill-registry --skill dast-nuclei -y` | DAST scanning with Nuclei templates, CVE detection, OWASP testing. | `/dast-nuclei` | When running dynamic scanning with Nuclei templates against a live target |
+| nuclei-scanner | TerminalSkills/skills | `npx skills@latest add TerminalSkills/skills --skill nuclei-scanner -y` | Vulnerability scanning with Nuclei, CVE detection. | `/nuclei-scanner` | When scanning for known CVEs with Nuclei against a running service |
+| ffuf-claude-skill | jthack/ffuf_claude_skill | `npx skills@latest add jthack/ffuf_claude_skill -y` | FFUF web fuzzing and reconnaissance. | `/ffuf-claude-skill` | When fuzzing web endpoints for hidden paths or parameters |
 
 ---
 
 ## Secrets Detection
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| gitleaks | majiayu000/claude-skill-registry | `npx skills@latest add majiayu000/claude-skill-registry --skill gitleaks -y` | Secret detection with Gitleaks. |
-| review-trufflehog | majiayu000/claude-skill-registry | `npx skills@latest add majiayu000/claude-skill-registry --skill review-trufflehog -y` | Review and triage TruffleHog scan results, prioritize verified findings. |
-| secrets-guardian | majiayu000/claude-skill-registry | `npx skills@latest add majiayu000/claude-skill-registry --skill secrets-guardian -y` | detect-secrets scanning across all files. |
-| cookbook-audit | anthropics/claude-cookbooks | `npx skills@latest add anthropics/claude-cookbooks --skill cookbook-audit -y` | detect-secrets scanning for hardcoded API keys with custom patterns. |
-| Clawdbot-Security-Check | TheSethRose/Clawdbot-Security-Check | `npx skills@latest add TheSethRose/Clawdbot-Security-Check -y` | Dynamic security posture audit with detect-secrets config checking. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| gitleaks | majiayu000/claude-skill-registry | `npx skills@latest add majiayu000/claude-skill-registry --skill gitleaks -y` | Secret detection with Gitleaks. | `gitleaks` | When scanning a repo for accidentally committed secrets |
+| review-trufflehog | majiayu000/claude-skill-registry | `npx skills@latest add majiayu000/claude-skill-registry --skill review-trufflehog -y` | Review and triage TruffleHog scan results, prioritize verified findings. | `/review-trufflehog` | When triaging and prioritising TruffleHog secret findings |
+| secrets-guardian | majiayu000/claude-skill-registry | `npx skills@latest add majiayu000/claude-skill-registry --skill secrets-guardian -y` | detect-secrets scanning across all files. | `/secrets-guardian` | When scanning all project files for hardcoded secrets |
+| cookbook-audit | anthropics/claude-cookbooks | `npx skills@latest add anthropics/claude-cookbooks --skill cookbook-audit -y` | detect-secrets scanning for hardcoded API keys with custom patterns. | `/cookbook-audit` | When auditing code for hardcoded API keys with custom detection patterns |
+| Clawdbot-Security-Check | TheSethRose/Clawdbot-Security-Check | `npx skills@latest add TheSethRose/Clawdbot-Security-Check -y` | Dynamic security posture audit with detect-secrets config checking. | `/Clawdbot-Security-Check` | When running a dynamic security posture audit with secrets config check |
 
 ---
 
 ## SCA (Dependency Security)
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| supply-chain-risk-auditor | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill supply-chain-risk-auditor -y` | Audit supply chain risks in project dependencies. |
-| security-reviewer | Jeffallan/claude-skills | `npx skills@latest add Jeffallan/claude-skills --skill security-reviewer -y` | Multi-tool: npm audit, Trivy, Gitleaks, TruffleHog, Semgrep, Bandit, Checkov. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| supply-chain-risk-auditor | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill supply-chain-risk-auditor -y` | Audit supply chain risks in project dependencies. | `/supply-chain-risk-auditor` | When auditing project dependencies for supply chain vulnerabilities |
+| security-reviewer | Jeffallan/claude-skills | `npx skills@latest add Jeffallan/claude-skills --skill security-reviewer -y` | Multi-tool: npm audit, Trivy, Gitleaks, TruffleHog, Semgrep, Bandit, Checkov. | `/security-reviewer` | When running a comprehensive multi-tool security scan across all dimensions |
 
 ---
 
 ## Container Security
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| trivy | majiayu000/claude-skill-registry | `npx skills@latest add majiayu000/claude-skill-registry --skill trivy -y` | Container images, filesystems, and IaC scanning. |
-| container-grype | AgentSecOps/SecOpsAgentKit | `npx skills@latest add AgentSecOps/SecOpsAgentKit --skill container-grype -y` | Container security, SCA, SBOM, CVSS, CVE scanning. |
-| grype | TerminalSkills/skills | `npx skills@latest add TerminalSkills/skills --skill grype -y` | Grype scanner with CI/CD integration and Syft SBOM. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| trivy | majiayu000/claude-skill-registry | `npx skills@latest add majiayu000/claude-skill-registry --skill trivy -y` | Container images, filesystems, and IaC scanning. | `trivy` | When scanning container images, filesystems, or IaC for vulnerabilities |
+| container-grype | AgentSecOps/SecOpsAgentKit | `npx skills@latest add AgentSecOps/SecOpsAgentKit --skill container-grype -y` | Container security, SCA, SBOM, CVSS, CVE scanning. | `/container-grype` | When scanning containers for CVEs and generating SBOMs |
+| grype | TerminalSkills/skills | `npx skills@latest add TerminalSkills/skills --skill grype -y` | Grype scanner with CI/CD integration and Syft SBOM. | `grype` | When integrating Grype into CI/CD with Syft SBOM generation |
 
 ---
 
 ## IaC Security
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| iac-checkov | AgentSecOps/SecOpsAgentKit | `npx skills@latest add AgentSecOps/SecOpsAgentKit --skill iac-checkov -y` | Checkov for Terraform, K8s, CloudFormation compliance. |
-| checkov | TerminalSkills/skills | `npx skills@latest add TerminalSkills/skills --skill checkov -y` | Checkov IaC static analysis and custom policy writing. |
-| iac-scanner | majiayu000/claude-skill-registry | `npx skills@latest add majiayu000/claude-skill-registry --skill iac-scanner -y` | tfsec + Checkov for multi-cloud IaC scanning. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| iac-checkov | AgentSecOps/SecOpsAgentKit | `npx skills@latest add AgentSecOps/SecOpsAgentKit --skill iac-checkov -y` | Checkov for Terraform, K8s, CloudFormation compliance. | `/iac-checkov` | When checking Terraform, K8s, or CloudFormation for compliance violations |
+| checkov | TerminalSkills/skills | `npx skills@latest add TerminalSkills/skills --skill checkov -y` | Checkov IaC static analysis and custom policy writing. | `checkov` | When running Checkov IaC static analysis and authoring custom policies |
+| iac-scanner | majiayu000/claude-skill-registry | `npx skills@latest add majiayu000/claude-skill-registry --skill iac-scanner -y` | tfsec + Checkov for multi-cloud IaC scanning. | `/iac-scanner` | When scanning multi-cloud IaC with tfsec and Checkov |
 
 ---
 
 ## Threat Modeling
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| threat-modeling | fr33d3m0n/threat-modeling | `npx skills@latest add fr33d3m0n/threat-modeling -y` | STRIDE/DREAD, MITRE ATT&CK mapping, OWASP MCP Top 10. |
-| cso | garrytan/gstack | `npx skills@latest add garrytan/gstack --skill cso -y` | CSO perspective: STRIDE, OWASP, supply chain, LLM/AI security. |
-| insecure-defaults | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill insecure-defaults -y` | Detect insecure defaults, hardcoded creds, fail-open patterns. |
-| sharp-edges | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill sharp-edges -y` | Identify dangerous APIs and footgun designs. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| threat-modeling | fr33d3m0n/threat-modeling | `npx skills@latest add fr33d3m0n/threat-modeling -y` | STRIDE/DREAD, MITRE ATT&CK mapping, OWASP MCP Top 10. | `/threat-modeling` | When performing structured threat modeling with STRIDE and ATT&CK |
+| cso | garrytan/gstack | `npx skills@latest add garrytan/gstack --skill cso -y` | CSO perspective: STRIDE, OWASP, supply chain, LLM/AI security. | `/cso` | When reviewing security from a CSO/CISO strategic perspective |
+| insecure-defaults | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill insecure-defaults -y` | Detect insecure defaults, hardcoded creds, fail-open patterns. | `/insecure-defaults` | When hunting for insecure defaults and fail-open patterns |
+| sharp-edges | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill sharp-edges -y` | Identify dangerous APIs and footgun designs. | `/sharp-edges` | When identifying dangerous API patterns and footgun-prone designs |
 
 ---
 
 ## Compliance (SOC2, HIPAA, PCI-DSS, GDPR)
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| governance-risk-compliance | Sushegaad/Claude-Skills-Governance-Risk-and-Compliance | `npx skills@latest add Sushegaad/Claude-Skills-Governance-Risk-and-Compliance -y` | **[99% eval]** ISO 27001, SOC 2, FedRAMP, GDPR, HIPAA. |
-| owasp-asi | Tencent/AI-Infra-Guard | `npx skills@latest add Tencent/AI-Infra-Guard --skill owasp-asi -y` | OWASP Top 10 for Agentic Applications 2026 classification. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| governance-risk-compliance | Sushegaad/Claude-Skills-Governance-Risk-and-Compliance | `npx skills@latest add Sushegaad/Claude-Skills-Governance-Risk-and-Compliance -y` | **[99% eval]** ISO 27001, SOC 2, FedRAMP, GDPR, HIPAA. | `/governance-risk-compliance` | When assessing compliance with SOC 2, HIPAA, GDPR, or ISO 27001 |
+| owasp-asi | Tencent/AI-Infra-Guard | `npx skills@latest add Tencent/AI-Infra-Guard --skill owasp-asi -y` | OWASP Top 10 for Agentic Applications 2026 classification. | `/owasp-asi` | When classifying agentic AI risks against OWASP Agentic App Top 10 |
 
 ---
 
 ## Penetration Testing
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| awesome-claude-skills-security | Eyadkelleh/awesome-claude-skills-security | `npx skills@latest add Eyadkelleh/awesome-claude-skills-security -y` | SecLists, injection payloads, pentest/CTF/bug-bounty agents. |
-| claude-skills-pentest | WolzenGeorgi/claude-skills-pentest | `npx skills@latest add WolzenGeorgi/claude-skills-pentest -y` | Automated pentesting with VPS scanner. |
-| burpsuite-project-parser | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill burpsuite-project-parser -y` | Parse Burp Suite project files for analysis. |
-| agentic-actions-auditor | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill agentic-actions-auditor -y` | Audit GitHub Actions for AI agent security risks. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| awesome-claude-skills-security | Eyadkelleh/awesome-claude-skills-security | `npx skills@latest add Eyadkelleh/awesome-claude-skills-security -y` | SecLists, injection payloads, pentest/CTF/bug-bounty agents. | `/awesome-claude-skills-security` | When running pentest, CTF, or bug-bounty workflows with payloads |
+| claude-skills-pentest | WolzenGeorgi/claude-skills-pentest | `npx skills@latest add WolzenGeorgi/claude-skills-pentest -y` | Automated pentesting with VPS scanner. | `/claude-skills-pentest` | When running automated penetration tests against a target |
+| burpsuite-project-parser | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill burpsuite-project-parser -y` | Parse Burp Suite project files for analysis. | `/burpsuite-project-parser` | When analysing Burp Suite project exports for security findings |
+| agentic-actions-auditor | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill agentic-actions-auditor -y` | Audit GitHub Actions for AI agent security risks. | `/agentic-actions-auditor` | When auditing GitHub Actions workflows for AI agent security risks |
 
 ---
 
 ## Smart Contract & Crypto Security
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| building-secure-contracts | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill building-secure-contracts -y` | Secure smart contract patterns, 6 blockchain scanners. |
-| constant-time-analysis | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill constant-time-analysis -y` | Detect timing side-channels in cryptographic code. |
-| zeroize-audit | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill zeroize-audit -y` | Audit memory zeroization for sensitive data handling. |
-| yara-authoring | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill yara-authoring -y` | YARA detection rule authoring for malware/threat detection. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| building-secure-contracts | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill building-secure-contracts -y` | Secure smart contract patterns, 6 blockchain scanners. | `/building-secure-contracts` | When writing or auditing smart contracts for security vulnerabilities |
+| constant-time-analysis | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill constant-time-analysis -y` | Detect timing side-channels in cryptographic code. | `/constant-time-analysis` | When detecting timing side-channels in cryptographic implementations |
+| zeroize-audit | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill zeroize-audit -y` | Audit memory zeroization for sensitive data handling. | `/zeroize-audit` | When auditing that sensitive data is properly zeroized from memory |
+| yara-authoring | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill yara-authoring -y` | YARA detection rule authoring for malware/threat detection. | `/yara-authoring` | When authoring YARA rules for malware detection |
 
 ---
 
 ## Framework-Specific Security
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| django-security | affaan-m/everything-claude-code | `npx skills@latest add affaan-m/everything-claude-code --skill django-security -y` | Django: CSRF, SQLi, XSS, secure deployment. |
-| laravel-security | affaan-m/everything-claude-code | `npx skills@latest add affaan-m/everything-claude-code --skill laravel-security -y` | Laravel: auth, validation, CSRF, mass assignment. |
-| springboot-security | affaan-m/everything-claude-code | `npx skills@latest add affaan-m/everything-claude-code --skill springboot-security -y` | Spring Security: auth, CSRF, headers, rate limiting. |
-| perl-security | affaan-m/everything-claude-code | `npx skills@latest add affaan-m/everything-claude-code --skill perl-security -y` | Perl: taint mode, DBI parameterized queries. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| django-security | affaan-m/everything-claude-code | `npx skills@latest add affaan-m/everything-claude-code --skill django-security -y` | Django: CSRF, SQLi, XSS, secure deployment. | `/django-security` | When hardening a Django application against CSRF, SQLi, and XSS |
+| laravel-security | affaan-m/everything-claude-code | `npx skills@latest add affaan-m/everything-claude-code --skill laravel-security -y` | Laravel: auth, validation, CSRF, mass assignment. | `/laravel-security` | When securing a Laravel application's auth and validation layer |
+| springboot-security | affaan-m/everything-claude-code | `npx skills@latest add affaan-m/everything-claude-code --skill springboot-security -y` | Spring Security: auth, CSRF, headers, rate limiting. | `/springboot-security` | When configuring Spring Security for auth, headers, and rate limiting |
+| perl-security | affaan-m/everything-claude-code | `npx skills@latest add affaan-m/everything-claude-code --skill perl-security -y` | Perl: taint mode, DBI parameterized queries. | `/perl-security` | When securing Perl code with taint mode and parameterized queries |
 
 ---
 
 ## Multi-Tool / Comprehensive
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| shield-claude-skill | alissonlinneker/shield-claude-skill | `npx skills@latest add alissonlinneker/shield-claude-skill -y` | Registers Semgrep + Gitleaks + Trivy as callable Claude tools. |
-| security (007) | sickn33/antigravity-awesome-skills | `npx skills@latest add sickn33/antigravity-awesome-skills --skill 007 -y` | Full audit: STRIDE/PASTA, Red/Blue Team, OWASP, incident response. |
-| anthropic-cybersecurity-skills | mukul975/Anthropic-Cybersecurity-Skills | `npx skills@latest add mukul975/Anthropic-Cybersecurity-Skills -y` | 734+ cybersecurity skills across 26 domains, MITRE ATT&CK mapped. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| shield-claude-skill | alissonlinneker/shield-claude-skill | `npx skills@latest add alissonlinneker/shield-claude-skill -y` | Registers Semgrep + Gitleaks + Trivy as callable Claude tools. | `/shield-claude-skill` | When registering Semgrep, Gitleaks, and Trivy as callable Claude tools |
+| security (007) | sickn33/antigravity-awesome-skills | `npx skills@latest add sickn33/antigravity-awesome-skills --skill 007 -y` | Full audit: STRIDE/PASTA, Red/Blue Team, OWASP, incident response. | `/007` | When running a full-spectrum security audit with Red/Blue team simulation |
+| anthropic-cybersecurity-skills | mukul975/Anthropic-Cybersecurity-Skills | `npx skills@latest add mukul975/Anthropic-Cybersecurity-Skills -y` | 734+ cybersecurity skills across 26 domains, MITRE ATT&CK mapped. | `/anthropic-cybersecurity-skills` | When accessing deep cybersecurity knowledge across 26 security domains |
 
 ---
 
 ## Incident Response & DFIR
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| awesome-dfir-skills | tsale/awesome-dfir-skills | `npx skills@latest add tsale/awesome-dfir-skills -y` | Digital Forensics and Incident Response skills for InfoSec. |
-| incident-commander | alirezarezvani/claude-skills | `/plugin install engineering-advanced-skills@claude-code-skills` | Incident response workflows: severity classification, communication templates, escalation, post-mortems. |
-| env-secrets-manager | alirezarezvani/claude-skills | `/plugin install engineering-advanced-skills@claude-code-skills` | Secrets rotation, vault integration, .env management across environments. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| awesome-dfir-skills | tsale/awesome-dfir-skills | `npx skills@latest add tsale/awesome-dfir-skills -y` | Digital Forensics and Incident Response skills for InfoSec. | `/awesome-dfir-skills` | When investigating a security incident with forensic analysis |
+| incident-commander | alirezarezvani/claude-skills | `/plugin install engineering-advanced-skills@claude-code-skills` | Incident response workflows: severity classification, communication templates, escalation, post-mortems. | `/incident-commander` | When coordinating an active incident response with escalation |
+| env-secrets-manager | alirezarezvani/claude-skills | `/plugin install engineering-advanced-skills@claude-code-skills` | Secrets rotation, vault integration, .env management across environments. | `/env-secrets-manager` | When rotating secrets or managing .env files across environments |
 
 ---
 
 ## Skill & MCP Security (Meta)
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| claude-code-skill-security-check | aliksir/claude-code-skill-security-check | `npx skills@latest add aliksir/claude-code-skill-security-check -y` | Scan skills for prompt injection, data exfiltration, permission bypass, supply chain risks. |
-| mcp-security-audit | larrygmaguire-hash/mcp-security-audit | `npx skills@latest add larrygmaguire-hash/mcp-security-audit -y` | Audit MCP servers before installation. |
-| safety-guard | affaan-m/everything-claude-code | `npx skills@latest add affaan-m/everything-claude-code --skill safety-guard -y` | Prevent destructive ops: rm -rf, force push, DROP TABLE, chmod 777. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| claude-code-skill-security-check | aliksir/claude-code-skill-security-check | `npx skills@latest add aliksir/claude-code-skill-security-check -y` | Scan skills for prompt injection, data exfiltration, permission bypass, supply chain risks. | `/claude-code-skill-security-check` | When vetting a new skill for prompt injection or supply chain risks |
+| mcp-security-audit | larrygmaguire-hash/mcp-security-audit | `npx skills@latest add larrygmaguire-hash/mcp-security-audit -y` | Audit MCP servers before installation. | `/mcp-security-audit` | When auditing an MCP server for security risks before installing |
+| safety-guard | affaan-m/everything-claude-code | `npx skills@latest add affaan-m/everything-claude-code --skill safety-guard -y` | Prevent destructive ops: rm -rf, force push, DROP TABLE, chmod 777. | `/safety-guard` | When adding guardrails to prevent dangerous destructive operations |
 
 ---
 

--- a/power-engineer/references/catalog/engineering/security-ops.md
+++ b/power-engineer/references/catalog/engineering/security-ops.md
@@ -23,6 +23,7 @@
 | variant-analysis | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill variant-analysis -y` | Find similar vulnerabilities across codebases using pattern analysis. | `/variant-analysis` | When finding variants of a known vulnerability across a codebase |
 | codeql | github/awesome-copilot | `npx skills@latest add github/awesome-copilot --skill codeql -y` | Comprehensive CodeQL code scanning via GitHub Actions and CLI. | `/codeql` | When running CodeQL scans via GitHub Actions or CLI |
 | sast-configuration | sickn33/antigravity-awesome-skills | `npx skills@latest add sickn33/antigravity-awesome-skills --skill sast-configuration -y` | SAST tool setup for Semgrep/SonarQube/CodeQL. | `/sast-configuration` | When configuring SAST tooling for a new project |
+| bandit-sast | kalshamsi/claude-security-skills | `npx skills@latest add kalshamsi/claude-security-skills --skill bandit-sast -y` | Python SAST scanning via Bandit with fallback manual checks. | `/bandit-sast` | When running Python-specific SAST with Bandit and manual fallback |
 
 ---
 
@@ -54,6 +55,7 @@
 |-------|--------|---------|-------------|---------|-------------|
 | supply-chain-risk-auditor | trailofbits/skills | `npx skills@latest add trailofbits/skills --skill supply-chain-risk-auditor -y` | Audit supply chain risks in project dependencies. | `/supply-chain-risk-auditor` | When auditing project dependencies for supply chain vulnerabilities |
 | security-reviewer | Jeffallan/claude-skills | `npx skills@latest add Jeffallan/claude-skills --skill security-reviewer -y` | Multi-tool: npm audit, Trivy, Gitleaks, TruffleHog, Semgrep, Bandit, Checkov. | `/security-reviewer` | When running a comprehensive multi-tool security scan across all dimensions |
+| socket-sca | kalshamsi/claude-security-skills | `npx skills@latest add kalshamsi/claude-security-skills --skill socket-sca -y` | Supply chain security analysis via Socket.dev CLI. | `/socket-sca` | When performing supply chain security analysis with Socket.dev |
 
 ---
 
@@ -64,6 +66,7 @@
 | trivy | majiayu000/claude-skill-registry | `npx skills@latest add majiayu000/claude-skill-registry --skill trivy -y` | Container images, filesystems, and IaC scanning. | `trivy` | When scanning container images, filesystems, or IaC for vulnerabilities |
 | container-grype | AgentSecOps/SecOpsAgentKit | `npx skills@latest add AgentSecOps/SecOpsAgentKit --skill container-grype -y` | Container security, SCA, SBOM, CVSS, CVE scanning. | `/container-grype` | When scanning containers for CVEs and generating SBOMs |
 | grype | TerminalSkills/skills | `npx skills@latest add TerminalSkills/skills --skill grype -y` | Grype scanner with CI/CD integration and Syft SBOM. | `grype` | When integrating Grype into CI/CD with Syft SBOM generation |
+| docker-scout-scanner | kalshamsi/claude-security-skills | `npx skills@latest add kalshamsi/claude-security-skills --skill docker-scout-scanner -y` | Container vulnerability scanning via Docker Scout. | `/docker-scout-scanner` | When scanning container images for vulnerabilities via Docker Scout |
 
 ---
 
@@ -94,6 +97,7 @@
 |-------|--------|---------|-------------|---------|-------------|
 | governance-risk-compliance | Sushegaad/Claude-Skills-Governance-Risk-and-Compliance | `npx skills@latest add Sushegaad/Claude-Skills-Governance-Risk-and-Compliance -y` | **[99% eval]** ISO 27001, SOC 2, FedRAMP, GDPR, HIPAA. | `/governance-risk-compliance` | When assessing compliance with SOC 2, HIPAA, GDPR, or ISO 27001 |
 | owasp-asi | Tencent/AI-Infra-Guard | `npx skills@latest add Tencent/AI-Infra-Guard --skill owasp-asi -y` | OWASP Top 10 for Agentic Applications 2026 classification. | `/owasp-asi` | When classifying agentic AI risks against OWASP Agentic App Top 10 |
+| pci-dss-audit | kalshamsi/claude-security-skills | `npx skills@latest add kalshamsi/claude-security-skills --skill pci-dss-audit -y` | PCI-DSS v4.0 compliance audit for payment code. | `/pci-dss-audit` | When auditing payment-handling code for PCI-DSS v4.0 compliance |
 
 ---
 
@@ -127,6 +131,19 @@
 | laravel-security | affaan-m/everything-claude-code | `npx skills@latest add affaan-m/everything-claude-code --skill laravel-security -y` | Laravel: auth, validation, CSRF, mass assignment. | `/laravel-security` | When securing a Laravel application's auth and validation layer |
 | springboot-security | affaan-m/everything-claude-code | `npx skills@latest add affaan-m/everything-claude-code --skill springboot-security -y` | Spring Security: auth, CSRF, headers, rate limiting. | `/springboot-security` | When configuring Spring Security for auth, headers, and rate limiting |
 | perl-security | affaan-m/everything-claude-code | `npx skills@latest add affaan-m/everything-claude-code --skill perl-security -y` | Perl: taint mode, DBI parameterized queries. | `/perl-security` | When securing Perl code with taint mode and parameterized queries |
+
+---
+
+## Security Testing & Analysis
+
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| crypto-audit | kalshamsi/claude-security-skills | `npx skills@latest add kalshamsi/claude-security-skills --skill crypto-audit -y` | Cryptographic vulnerability detection across Python, JS, Go, Rust, Java. | `/crypto-audit` | When auditing cryptographic implementations across multi-language codebases |
+| security-headers-audit | kalshamsi/claude-security-skills | `npx skills@latest add kalshamsi/claude-security-skills --skill security-headers-audit -y` | HTTP security header configuration audit. | `/security-headers-audit` | When auditing HTTP response headers for security misconfigurations |
+| api-security-tester | kalshamsi/claude-security-skills | `npx skills@latest add kalshamsi/claude-security-skills --skill api-security-tester -y` | API security audit for OWASP API Security Top 10:2023. | `/api-security-tester` | When auditing an API against the OWASP API Security Top 10:2023 |
+| mobile-security | kalshamsi/claude-security-skills | `npx skills@latest add kalshamsi/claude-security-skills --skill mobile-security -y` | Mobile app security audit for OWASP Mobile Top 10:2024. | `/mobile-security` | When auditing a mobile application against OWASP Mobile Top 10:2024 |
+| security-test-generator | kalshamsi/claude-security-skills | `npx skills@latest add kalshamsi/claude-security-skills --skill security-test-generator -y` | Generate executable security test suites for web apps. | `/security-test-generator` | When generating executable security test suites for a web application |
+| devsecops-pipeline | kalshamsi/claude-security-skills | `npx skills@latest add kalshamsi/claude-security-skills --skill devsecops-pipeline -y` | Generate GitHub Actions security CI/CD pipelines. | `/devsecops-pipeline` | When setting up a security-focused GitHub Actions CI/CD pipeline |
 
 ---
 

--- a/power-engineer/references/catalog/engineering/testing-quality.md
+++ b/power-engineer/references/catalog/engineering/testing-quality.md
@@ -2,30 +2,30 @@
 
 ## Testing Frameworks
 
-| Skill | Source | Scope | Install | Description |
-|-------|--------|-------|---------|-------------|
-| playwright-pro | alirezarezvani/claude-skills | `local` | `/plugin install playwright-pro@claude-code-skills` | Production Playwright testing: 55 templates, 3 agents, CI/CD integration, TestRail sync, BrowserStack, migration from Cypress/Selenium. |
-| playwright-best-practices | currents-dev | `local` | `npx skills@latest add currents-dev/playwright-best-practices-skill --skill playwright-best-practices -y` | Playwright patterns: page objects, fixtures, parallel execution, visual regression, CI. |
-| webapp-testing | anthropics/skills | `local` | `npx skills@latest add anthropics/skills --skill webapp-testing -y` | E2E web app testing strategies with browser automation and assertion patterns. |
-| api-test-suite-builder | alirezarezvani/claude-skills | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Automated API test generation: endpoint discovery, edge case coverage, contract testing. |
+| Skill | Source | Scope | Install | Description | Trigger | When to use |
+|-------|--------|-------|---------|-------------|---------|-------------|
+| playwright-pro | alirezarezvani/claude-skills | `local` | `/plugin install playwright-pro@claude-code-skills` | Production Playwright testing: 55 templates, 3 agents, CI/CD integration, TestRail sync, BrowserStack, migration from Cypress/Selenium. | `/playwright-pro` | When building production-grade Playwright test suites |
+| playwright-best-practices | currents-dev | `local` | `npx skills@latest add currents-dev/playwright-best-practices-skill --skill playwright-best-practices -y` | Playwright patterns: page objects, fixtures, parallel execution, visual regression, CI. | `/playwright-best-practices` | When applying Playwright patterns for page objects and visual regression |
+| webapp-testing | anthropics/skills | `local` | `npx skills@latest add anthropics/skills --skill webapp-testing -y` | E2E web app testing strategies with browser automation and assertion patterns. | `/webapp-testing` | When designing E2E test strategies for a web application |
+| api-test-suite-builder | alirezarezvani/claude-skills | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Automated API test generation: endpoint discovery, edge case coverage, contract testing. | `/api-test-suite-builder` | When generating comprehensive API tests with contract coverage |
 
 ---
 
 ## Testing Strategy — supercent-io/skills-template
 
-| Skill | Scope | Install | Description |
-|-------|-------|---------|-------------|
-| backend-testing | `local` | `npx skills@latest add supercent-io/skills-template --skill backend-testing -y` | Backend test strategies: unit, integration, contract, and API testing patterns. |
-| testing-strategies | `local` | `npx skills@latest add supercent-io/skills-template --skill testing-strategies -y` | Testing pyramid strategy: unit, integration, E2E ratios and tooling selection. |
+| Skill | Scope | Install | Description | Trigger | When to use |
+|-------|-------|---------|-------------|---------|-------------|
+| backend-testing | `local` | `npx skills@latest add supercent-io/skills-template --skill backend-testing -y` | Backend test strategies: unit, integration, contract, and API testing patterns. | `/backend-testing` | When setting up or improving backend test coverage strategies |
+| testing-strategies | `local` | `npx skills@latest add supercent-io/skills-template --skill testing-strategies -y` | Testing pyramid strategy: unit, integration, E2E ratios and tooling selection. | `/testing-strategies` | When planning test coverage ratios and tool selection for a project |
 
 ---
 
 ## Code Quality & Tech Debt
 
-| Skill | Source | Scope | Install | Description |
-|-------|--------|-------|---------|-------------|
-| tech-debt-tracker | alirezarezvani/claude-skills | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Scans codebases for tech debt, scores severity, tracks trends over time, generates prioritized remediation plans. |
-| codebase-onboarding | alirezarezvani/claude-skills | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Generates onboarding guides for new developers joining a codebase: architecture overview, key patterns, setup steps. |
-| code-refactoring | supercent-io | `local` | `npx skills@latest add supercent-io/skills-template --skill code-refactoring -y` | Systematic refactoring: clean code principles, SOLID, progressive improvements. |
-| code-review | supercent-io | `local` | `npx skills@latest add supercent-io/skills-template --skill code-review -y` | Structured code review process: security, performance, maintainability checks. |
-| debugging | supercent-io | `local` | `npx skills@latest add supercent-io/skills-template --skill debugging -y` | Systematic debugging approach with structured problem isolation techniques. |
+| Skill | Source | Scope | Install | Description | Trigger | When to use |
+|-------|--------|-------|---------|-------------|---------|-------------|
+| tech-debt-tracker | alirezarezvani/claude-skills | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Scans codebases for tech debt, scores severity, tracks trends over time, generates prioritized remediation plans. | `/tech-debt-tracker` | When auditing a codebase for tech debt severity and remediation priority |
+| codebase-onboarding | alirezarezvani/claude-skills | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Generates onboarding guides for new developers joining a codebase: architecture overview, key patterns, setup steps. | `/codebase-onboarding` | When onboarding a new developer to an existing codebase |
+| code-refactoring | supercent-io | `local` | `npx skills@latest add supercent-io/skills-template --skill code-refactoring -y` | Systematic refactoring: clean code principles, SOLID, progressive improvements. | `/code-refactoring` | When systematically improving code quality with SOLID principles |
+| code-review | supercent-io | `local` | `npx skills@latest add supercent-io/skills-template --skill code-review -y` | Structured code review process: security, performance, maintainability checks. | `/code-review` | When conducting a structured code review across security and performance |
+| debugging | supercent-io | `local` | `npx skills@latest add supercent-io/skills-template --skill debugging -y` | Systematic debugging approach with structured problem isolation techniques. | `/debugging` | When systematically isolating and resolving a bug |

--- a/power-engineer/references/catalog/frontend/design-systems.md
+++ b/power-engineer/references/catalog/frontend/design-systems.md
@@ -5,14 +5,14 @@
 Requires the Stitch MCP server to be configured. Enables text/sketch to
 high-fidelity UI to production React/Tailwind code via Gemini 2.5 Pro.
 
-| Skill | Install | Description |
-|-------|---------|-------------|
-| stitch-loop | `npx skills@latest add google-labs-code/stitch-skills --skill stitch-loop -y` | Generates a complete multi-page website from a single prompt. |
-| enhance-prompt | `npx skills@latest add google-labs-code/stitch-skills --skill enhance-prompt -y` | Transforms vague UI ideas into Stitch-optimised prompts with design system context. |
-| react:components | `npx skills@latest add google-labs-code/stitch-skills --skill react:components -y` | Converts Stitch screens into React component systems with design token consistency. |
-| design-md | `npx skills@latest add google-labs-code/stitch-skills --skill design-md -y` | Analyses Stitch projects and generates DESIGN.md files in semantic language. |
-| shadcn-ui (stitch) | `npx skills@latest add google-labs-code/stitch-skills --skill shadcn-ui -y` | Stitch-aligned shadcn/ui integration for React applications. |
-| remotion | `npx skills@latest add google-labs-code/stitch-skills --skill remotion -y` | Generates walkthrough videos from Stitch projects via Remotion. |
+| Skill | Install | Description | Trigger | When to use |
+|-------|---------|-------------|---------|-------------|
+| stitch-loop | `npx skills@latest add google-labs-code/stitch-skills --skill stitch-loop -y` | Generates a complete multi-page website from a single prompt. | `/stitch-loop` | When generating a full multi-page website from a text prompt |
+| enhance-prompt | `npx skills@latest add google-labs-code/stitch-skills --skill enhance-prompt -y` | Transforms vague UI ideas into Stitch-optimised prompts with design system context. | `/enhance-prompt` | When refining a vague UI idea into a Stitch-ready design prompt |
+| react:components | `npx skills@latest add google-labs-code/stitch-skills --skill react:components -y` | Converts Stitch screens into React component systems with design token consistency. | `/react:components` | When converting Stitch screens into production React components |
+| design-md | `npx skills@latest add google-labs-code/stitch-skills --skill design-md -y` | Analyses Stitch projects and generates DESIGN.md files in semantic language. | `/design-md` | When documenting a Stitch project's design system in DESIGN.md |
+| shadcn-ui (stitch) | `npx skills@latest add google-labs-code/stitch-skills --skill shadcn-ui -y` | Stitch-aligned shadcn/ui integration for React applications. | `/shadcn-ui` | When integrating shadcn/ui components into a Stitch-based React app |
+| remotion | `npx skills@latest add google-labs-code/stitch-skills --skill remotion -y` | Generates walkthrough videos from Stitch projects via Remotion. | `/remotion` | When generating video walkthroughs of a Stitch project via Remotion |
 
 **Install all Stitch skills at once:**
 ```bash
@@ -23,15 +23,15 @@ npx skills@latest add google-labs-code/stitch-skills --all -y
 
 ## Frontend Design
 
-| Skill | Source | Install | Description |
-|-------|--------|---------|-------------|
-| web-design-guidelines | vercel-labs | `npx skills@latest add vercel-labs/agent-skills --skill web-design-guidelines -y` | Comprehensive web design guidelines: layout, spacing, typography, accessibility. |
-| tailwind-design-system | wshobson | `npx skills@latest add wshobson/agents --skill tailwind-design-system -y` | Tailwind design system: tokens, variants, responsive utilities, component APIs. |
-| shadcn | shadcn/ui | `npx skills@latest add shadcn/ui --skill shadcn -y` | Official shadcn/ui: component discovery, installation, customisation, composition. |
-| platform-design-skills | ehmo | `npx skills@latest add ehmo/platform-design-skills --skill platform-design-skills -y` | 300+ design rules from Apple HIG, Material Design 3, and WCAG 2.2. |
-| ui-component-patterns | supercent-io | `npx skills@latest add supercent-io/skills-template --skill ui-component-patterns -y` | Component composition patterns, compound components, headless UI strategies. |
-| responsive-design | supercent-io | `npx skills@latest add supercent-io/skills-template --skill responsive-design -y` | Mobile-first responsive layouts, breakpoint strategy, fluid typography. |
-| web-accessibility | supercent-io | `npx skills@latest add supercent-io/skills-template --skill web-accessibility -y` | WCAG 2.2 compliance, ARIA, keyboard navigation, screen reader testing. |
+| Skill | Source | Install | Description | Trigger | When to use |
+|-------|--------|---------|-------------|---------|-------------|
+| web-design-guidelines | vercel-labs | `npx skills@latest add vercel-labs/agent-skills --skill web-design-guidelines -y` | Comprehensive web design guidelines: layout, spacing, typography, accessibility. | `/web-design-guidelines` | When establishing layout, spacing, and typography guidelines for a site |
+| tailwind-design-system | wshobson | `npx skills@latest add wshobson/agents --skill tailwind-design-system -y` | Tailwind design system: tokens, variants, responsive utilities, component APIs. | `/tailwind-design-system` | When building a Tailwind design token system and component API |
+| shadcn | shadcn/ui | `npx skills@latest add shadcn/ui --skill shadcn -y` | Official shadcn/ui: component discovery, installation, customisation, composition. | `/shadcn` | When adding, customising, or composing shadcn/ui components |
+| platform-design-skills | ehmo | `npx skills@latest add ehmo/platform-design-skills --skill platform-design-skills -y` | 300+ design rules from Apple HIG, Material Design 3, and WCAG 2.2. | `/platform-design-skills` | When designing UIs to Apple HIG, Material Design 3, or WCAG standards |
+| ui-component-patterns | supercent-io | `npx skills@latest add supercent-io/skills-template --skill ui-component-patterns -y` | Component composition patterns, compound components, headless UI strategies. | `/ui-component-patterns` | When designing compound components or headless UI abstractions |
+| responsive-design | supercent-io | `npx skills@latest add supercent-io/skills-template --skill responsive-design -y` | Mobile-first responsive layouts, breakpoint strategy, fluid typography. | `/responsive-design` | When implementing mobile-first responsive layouts and fluid typography |
+| web-accessibility | supercent-io | `npx skills@latest add supercent-io/skills-template --skill web-accessibility -y` | WCAG 2.2 compliance, ARIA, keyboard navigation, screen reader testing. | `/web-accessibility` | When auditing or improving WCAG 2.2 accessibility compliance |
 
 ---
 
@@ -39,19 +39,19 @@ npx skills@latest add google-labs-code/stitch-skills --all -y
 
 A suite of focused design refinement skills for iterating on UI quality.
 
-| Skill | Install | Description |
-|-------|---------|-------------|
-| frontend-design (impeccable) | `npx skills@latest add pbakaus/impeccable --skill frontend-design -y` | Opinionated frontend design principles: bold, distinctive, non-generic UI. |
-| polish | `npx skills@latest add pbakaus/impeccable --skill polish -y` | Refines rough UI into polished, production-ready output. |
-| critique | `npx skills@latest add pbakaus/impeccable --skill critique -y` | Structured, honest critique of UI/UX decisions. |
-| adapt | `npx skills@latest add pbakaus/impeccable --skill adapt -y` | Adapts design to different contexts, devices, or audiences. |
-| clarify | `npx skills@latest add pbakaus/impeccable --skill clarify -y` | Removes visual noise, improves hierarchy and clarity. |
-| audit | `npx skills@latest add pbakaus/impeccable --skill audit -y` | Audits existing UI against design principles and identifies issues. |
-| animate | `npx skills@latest add pbakaus/impeccable --skill animate -y` | Adds purposeful motion and animation to UI components. |
-| bolder | `npx skills@latest add pbakaus/impeccable --skill bolder -y` | Makes UI more decisive, confident, and visually assertive. |
-| delight | `npx skills@latest add pbakaus/impeccable --skill delight -y` | Adds delightful micro-interactions and surprise moments. |
-| distill | `npx skills@latest add pbakaus/impeccable --skill distill -y` | Reduces a design to its essential elements. |
-| extract | `npx skills@latest add pbakaus/impeccable --skill extract -y` | Extracts reusable design patterns and tokens from existing UI. |
-| onboard | `npx skills@latest add pbakaus/impeccable --skill onboard -y` | Designs clear, effective onboarding experiences. |
-| harden | `npx skills@latest add pbakaus/impeccable --skill harden -y` | Makes UI resilient: empty states, error states, loading states, edge cases. |
-| quieter | `npx skills@latest add pbakaus/impeccable --skill quieter -y` | Reduces visual noise; calm, focused, minimal. |
+| Skill | Install | Description | Trigger | When to use |
+|-------|---------|-------------|---------|-------------|
+| frontend-design (impeccable) | `npx skills@latest add pbakaus/impeccable --skill frontend-design -y` | Opinionated frontend design principles: bold, distinctive, non-generic UI. | `/frontend-design` | When applying bold, distinctive design principles to a UI |
+| polish | `npx skills@latest add pbakaus/impeccable --skill polish -y` | Refines rough UI into polished, production-ready output. | `/polish` | When refining a rough UI mockup into production-ready quality |
+| critique | `npx skills@latest add pbakaus/impeccable --skill critique -y` | Structured, honest critique of UI/UX decisions. | `/critique` | When getting an honest structured critique of UI/UX decisions |
+| adapt | `npx skills@latest add pbakaus/impeccable --skill adapt -y` | Adapts design to different contexts, devices, or audiences. | `/adapt` | When adapting a design to a new device, context, or audience |
+| clarify | `npx skills@latest add pbakaus/impeccable --skill clarify -y` | Removes visual noise, improves hierarchy and clarity. | `/clarify` | When reducing visual noise and improving information hierarchy |
+| audit | `npx skills@latest add pbakaus/impeccable --skill audit -y` | Audits existing UI against design principles and identifies issues. | `/audit` | When auditing an existing UI against established design principles |
+| animate | `npx skills@latest add pbakaus/impeccable --skill animate -y` | Adds purposeful motion and animation to UI components. | `/animate` | When adding purposeful motion and transitions to UI components |
+| bolder | `npx skills@latest add pbakaus/impeccable --skill bolder -y` | Makes UI more decisive, confident, and visually assertive. | `/bolder` | When a design needs more visual confidence and assertiveness |
+| delight | `npx skills@latest add pbakaus/impeccable --skill delight -y` | Adds delightful micro-interactions and surprise moments. | `/delight` | When adding micro-interactions and surprise moments to UI |
+| distill | `npx skills@latest add pbakaus/impeccable --skill distill -y` | Reduces a design to its essential elements. | `/distill` | When stripping a design down to its most essential elements |
+| extract | `npx skills@latest add pbakaus/impeccable --skill extract -y` | Extracts reusable design patterns and tokens from existing UI. | `/extract` | When extracting reusable tokens and patterns from an existing UI |
+| onboard | `npx skills@latest add pbakaus/impeccable --skill onboard -y` | Designs clear, effective onboarding experiences. | `/onboard` | When designing user onboarding flows that are clear and effective |
+| harden | `npx skills@latest add pbakaus/impeccable --skill harden -y` | Makes UI resilient: empty states, error states, loading states, edge cases. | `/harden` | When making UI resilient with empty, error, and loading states |
+| quieter | `npx skills@latest add pbakaus/impeccable --skill quieter -y` | Reduces visual noise; calm, focused, minimal. | `/quieter` | When making a UI calmer, more focused, and minimal |

--- a/power-engineer/references/catalog/frontend/mobile.md
+++ b/power-engineer/references/catalog/frontend/mobile.md
@@ -2,23 +2,23 @@
 
 ## Expo / React Native
 
-| Skill | Scope | Install | Description |
-|-------|-------|---------|-------------|
-| building-native-ui | `local` | `npx skills@latest add expo/skills --skill building-native-ui -y` | Platform-specific native UI components, animations, accessibility. |
-| native-data-fetching | `local` | `npx skills@latest add expo/skills --skill native-data-fetching -y` | Data fetching for React Native: caching, background sync, offline support. |
-| upgrading-expo | `local` | `npx skills@latest add expo/skills --skill upgrading-expo -y` | Expo SDK upgrade process, breaking change navigation, migration checklist. |
-| expo-tailwind-setup | `local` | `npx skills@latest add expo/skills --skill expo-tailwind-setup -y` | NativeWind/Tailwind setup in Expo projects with theme configuration. |
-| expo-cicd-workflows | `local` | `npx skills@latest add expo/skills --skill expo-cicd-workflows -y` | EAS Build, EAS Submit, and GitHub Actions CI/CD for Expo apps. |
-| expo-api-routes | `local` | `npx skills@latest add expo/skills --skill expo-api-routes -y` | Expo Router API routes: server functions, middleware, edge deployment. |
-| expo-dev-client | `local` | `npx skills@latest add expo/skills --skill expo-dev-client -y` | Custom dev client setup: native modules, splash screen, app config. |
-| expo-deployment | `local` | `npx skills@latest add expo/skills --skill expo-deployment -y` | App Store and Google Play submission via EAS Submit. |
-| vercel-react-native-skills | `local` | `npx skills@latest add vercel-labs/agent-skills --skill vercel-react-native-skills -y` | React Native: platform patterns, navigation, gestures, native modules, performance. |
+| Skill | Scope | Install | Description | Trigger | When to use |
+|-------|-------|---------|-------------|---------|-------------|
+| building-native-ui | `local` | `npx skills@latest add expo/skills --skill building-native-ui -y` | Platform-specific native UI components, animations, accessibility. | `/building-native-ui` | When building platform-specific native UI with animations |
+| native-data-fetching | `local` | `npx skills@latest add expo/skills --skill native-data-fetching -y` | Data fetching for React Native: caching, background sync, offline support. | `/native-data-fetching` | When implementing offline-capable data fetching in React Native |
+| upgrading-expo | `local` | `npx skills@latest add expo/skills --skill upgrading-expo -y` | Expo SDK upgrade process, breaking change navigation, migration checklist. | `/upgrading-expo` | When upgrading an Expo project to a new SDK version |
+| expo-tailwind-setup | `local` | `npx skills@latest add expo/skills --skill expo-tailwind-setup -y` | NativeWind/Tailwind setup in Expo projects with theme configuration. | `/expo-tailwind-setup` | When setting up NativeWind/Tailwind in an Expo project |
+| expo-cicd-workflows | `local` | `npx skills@latest add expo/skills --skill expo-cicd-workflows -y` | EAS Build, EAS Submit, and GitHub Actions CI/CD for Expo apps. | `/expo-cicd-workflows` | When setting up EAS Build and CI/CD for an Expo app |
+| expo-api-routes | `local` | `npx skills@latest add expo/skills --skill expo-api-routes -y` | Expo Router API routes: server functions, middleware, edge deployment. | `/expo-api-routes` | When adding server functions or API routes to an Expo Router app |
+| expo-dev-client | `local` | `npx skills@latest add expo/skills --skill expo-dev-client -y` | Custom dev client setup: native modules, splash screen, app config. | `/expo-dev-client` | When configuring a custom Expo dev client with native modules |
+| expo-deployment | `local` | `npx skills@latest add expo/skills --skill expo-deployment -y` | App Store and Google Play submission via EAS Submit. | `/expo-deployment` | When submitting an Expo app to the App Store or Google Play |
+| vercel-react-native-skills | `local` | `npx skills@latest add vercel-labs/agent-skills --skill vercel-react-native-skills -y` | React Native: platform patterns, navigation, gestures, native modules, performance. | `/vercel-react-native-skills` | When building React Native apps with navigation, gestures, and native modules |
 
 ---
 
 ## SwiftUI / iOS
 
-| Skill | Scope | Install | Description |
-|-------|-------|---------|-------------|
-| swiftui-expert-skill | `local` | `npx skills@latest add avdlee/swiftui-agent-skill --skill swiftui-expert-skill -y` | Modern SwiftUI + iOS 26 Liquid Glass: views, data flow, animations, best practices. |
-| platform-design-skills | `local` | `npx skills@latest add ehmo/platform-design-skills --skill platform-design-skills -y` | 300+ design rules from Apple HIG, Material Design 3, and WCAG 2.2. |
+| Skill | Scope | Install | Description | Trigger | When to use |
+|-------|-------|---------|-------------|---------|-------------|
+| swiftui-expert-skill | `local` | `npx skills@latest add avdlee/swiftui-agent-skill --skill swiftui-expert-skill -y` | Modern SwiftUI + iOS 26 Liquid Glass: views, data flow, animations, best practices. | `/swiftui-expert-skill` | When building modern SwiftUI views with iOS 26 Liquid Glass patterns |
+| platform-design-skills | `local` | `npx skills@latest add ehmo/platform-design-skills --skill platform-design-skills -y` | 300+ design rules from Apple HIG, Material Design 3, and WCAG 2.2. | `/platform-design-skills` | When designing to Apple HIG, Material Design 3, or WCAG standards |

--- a/power-engineer/references/catalog/frontend/react-next.md
+++ b/power-engineer/references/catalog/frontend/react-next.md
@@ -2,19 +2,19 @@
 
 ## Vercel — React & Next.js
 
-| Skill | Scope | Install | Description |
-|-------|-------|---------|-------------|
-| vercel-react-best-practices | `local` | `npx skills@latest add vercel-labs/agent-skills --skill vercel-react-best-practices -y` | React component architecture, performance, server components, data fetching. |
-| vercel-composition-patterns | `local` | `npx skills@latest add vercel-labs/agent-skills --skill vercel-composition-patterns -y` | Advanced React composition: render props, compound components, context patterns. |
-| deploy-to-vercel | `local` | `npx skills@latest add vercel-labs/agent-skills --skill deploy-to-vercel -y` | Vercel deployment: project setup, environment variables, preview deployments, edge config. |
-| next-best-practices | `local` | `npx skills@latest add vercel-labs/next-skills --skill next-best-practices -y` | Next.js: App Router, RSC, layouts, metadata, fonts, images, deployment. |
-| next-cache-components | `local` | `npx skills@latest add vercel-labs/next-skills --skill next-cache-components -y` | Next.js caching strategies, revalidation, partial prerendering, streaming. |
-| turborepo | `local` | `npx skills@latest add vercel/turborepo --skill turborepo -y` | Turborepo monorepo: caching, pipeline config, remote caching, workspace management. |
+| Skill | Scope | Install | Description | Trigger | When to use |
+|-------|-------|---------|-------------|---------|-------------|
+| vercel-react-best-practices | `local` | `npx skills@latest add vercel-labs/agent-skills --skill vercel-react-best-practices -y` | React component architecture, performance, server components, data fetching. | `/vercel-react-best-practices` | When building React apps with server components and optimised data fetching |
+| vercel-composition-patterns | `local` | `npx skills@latest add vercel-labs/agent-skills --skill vercel-composition-patterns -y` | Advanced React composition: render props, compound components, context patterns. | `/vercel-composition-patterns` | When designing advanced React component composition patterns |
+| deploy-to-vercel | `local` | `npx skills@latest add vercel-labs/agent-skills --skill deploy-to-vercel -y` | Vercel deployment: project setup, environment variables, preview deployments, edge config. | `/deploy-to-vercel` | When deploying a project to Vercel with env vars and preview URLs |
+| next-best-practices | `local` | `npx skills@latest add vercel-labs/next-skills --skill next-best-practices -y` | Next.js: App Router, RSC, layouts, metadata, fonts, images, deployment. | `/next-best-practices` | When building or auditing a Next.js App Router project |
+| next-cache-components | `local` | `npx skills@latest add vercel-labs/next-skills --skill next-cache-components -y` | Next.js caching strategies, revalidation, partial prerendering, streaming. | `/next-cache-components` | When optimising Next.js caching, revalidation, or streaming |
+| turborepo | `local` | `npx skills@latest add vercel/turborepo --skill turborepo -y` | Turborepo monorepo: caching, pipeline config, remote caching, workspace management. | `/turborepo` | When configuring or optimising a Turborepo monorepo pipeline |
 
 ---
 
 ## Cinematic Web Design — alirezarezvani/claude-skills
 
-| Skill | Scope | Install | Description |
-|-------|-------|---------|-------------|
-| epic-design | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Cinematic 2.5D interactive websites: scroll storytelling, parallax depth, 45+ animation techniques (clip-path reveals, curtain drops, iris opens, card stacks). No WebGL required. |
+| Skill | Scope | Install | Description | Trigger | When to use |
+|-------|-------|---------|-------------|---------|-------------|
+| epic-design | `local` | `/plugin install engineering-advanced-skills@claude-code-skills` | Cinematic 2.5D interactive websites: scroll storytelling, parallax depth, 45+ animation techniques (clip-path reveals, curtain drops, iris opens, card stacks). No WebGL required. | `/epic-design` | When building cinematic scroll-storytelling or parallax web experiences |

--- a/power-engineer/references/catalog/frontend/vue-vite.md
+++ b/power-engineer/references/catalog/frontend/vue-vite.md
@@ -1,7 +1,7 @@
 # Vue & Vite
 
-| Skill | Source | Scope | Install | Description |
-|-------|--------|-------|---------|-------------|
-| vue-best-practices | hyf0/vue-skills | `local` | `npx skills@latest add hyf0/vue-skills --skill vue-best-practices -y` | Vue 3 composition API, Pinia, reactivity system, performance patterns. |
-| vue | antfu/skills | `local` | `npx skills@latest add antfu/skills --skill vue -y` | Anthony Fu's Vue skill: opinionated Vue patterns, composables, ecosystem. |
-| vite | antfu/skills | `local` | `npx skills@latest add antfu/skills --skill vite -y` | Vite configuration, plugins, SSR, optimisation, and ecosystem. |
+| Skill | Source | Scope | Install | Description | Trigger | When to use |
+|-------|--------|-------|---------|-------------|---------|-------------|
+| vue-best-practices | hyf0/vue-skills | `local` | `npx skills@latest add hyf0/vue-skills --skill vue-best-practices -y` | Vue 3 composition API, Pinia, reactivity system, performance patterns. | `/vue-best-practices` | When building Vue 3 apps with Pinia and composition API patterns |
+| vue | antfu/skills | `local` | `npx skills@latest add antfu/skills --skill vue -y` | Anthony Fu's Vue skill: opinionated Vue patterns, composables, ecosystem. | `/vue` | When following Anthony Fu's opinionated Vue patterns and composables |
+| vite | antfu/skills | `local` | `npx skills@latest add antfu/skills --skill vite -y` | Vite configuration, plugins, SSR, optimisation, and ecosystem. | `/vite` | When configuring Vite plugins, SSR, or build optimisation |

--- a/power-engineer/references/catalog/power-suites.md
+++ b/power-engineer/references/catalog/power-suites.md
@@ -26,6 +26,10 @@ npx skills@latest add ctsstc/get-shit-done-skills --skill gsd -y
 **Commands:** `/gsd:discuss-phase`, `/gsd:plan-phase`, `/gsd:execute-phase`,
 `/gsd:verify-work`, `/gsd:ship`, `/gsd:map-codebase`
 
+| Suite | Trigger | When to use |
+|-------|---------|-------------|
+| GSD | `/gsd:discuss-phase` | When starting a greenfield project and need a structured end-to-end shipping workflow |
+
 ---
 
 ## Superpowers by obra
@@ -43,6 +47,10 @@ TDD -> verify at every stage. 20+ battle-tested skills.
 
 **Commands:** `/superpowers:brainstorm`, `/superpowers:write-plan`,
 `/superpowers:execute-plan` + 17 auto-activating skills.
+
+| Suite | Trigger | When to use |
+|-------|---------|-------------|
+| Superpowers | `/superpowers:brainstorm` | When you want auto-activating brainstorm → plan → TDD → verify at every dev stage |
 
 ---
 
@@ -63,6 +71,10 @@ shadcn/ui, Jetpack Compose, HTML+Tailwind. Auto-activates on any UI/UX request.
 npm install -g uipro-cli && uipro init --ai claude
 ```
 
+| Suite | Trigger | When to use |
+|-------|---------|-------------|
+| UI/UX Pro Max | `auto` on UI/UX requests | When building UI for React, Next.js, Vue, SwiftUI, or any of 9 supported tech stacks |
+
 ---
 
 ## Designer Skills Collection -- 63 skills + 27 commands
@@ -77,6 +89,10 @@ Prototyping & Testing, Design Ops, Designer Toolkit.
 ```
 /plugin marketplace add Owl-Listener/designer-skills
 ```
+
+| Suite | Trigger | When to use |
+|-------|---------|-------------|
+| Designer Skills Collection | `/discover` | When doing UX research, design systems, prototyping, or design ops work |
 
 ---
 
@@ -101,6 +117,10 @@ npx skills@latest add google-labs-code/stitch-skills --skill shadcn-ui -y
 npx skills@latest add google-labs-code/stitch-skills --skill remotion -y
 ```
 
+| Suite | Trigger | When to use |
+|-------|---------|-------------|
+| Google Stitch Skills | `/stitch-loop` | When turning text or sketches into high-fidelity UI and React/Tailwind code |
+
 ---
 
 ## Pencil -- Built-in, no install needed
@@ -118,6 +138,10 @@ Works with `.pen` design files directly in VS Code via the Pencil companion exte
 - `pencil:get_screenshot` -- capture current canvas state
 
 **VS Code setup:** Search "Pencil" in the Extension Marketplace.
+
+| Suite | Trigger | When to use |
+|-------|---------|-------------|
+| Pencil | `pencil:batch_design` | When designing or editing `.pen` design files directly in the Claude environment |
 
 ---
 
@@ -137,3 +161,7 @@ Works with `.pen` design files directly in VS Code via the Pencil companion exte
 ```
 
 See individual catalog files for specific skills from this collection.
+
+| Suite | Trigger | When to use |
+|-------|---------|-------------|
+| alirezarezvani/claude-skills | `/plugin install engineering-skills@claude-code-skills` | When installing production-ready skills across engineering, marketing, product, or compliance |

--- a/power-engineer/references/flows/configure.md
+++ b/power-engineer/references/flows/configure.md
@@ -1,0 +1,82 @@
+# Configure Flow
+
+Manage Power Engineer preferences.
+
+## Step 1: Check for setup
+
+Check if `.power-engineer/state.json` exists.
+
+If it does not exist, respond with:
+> No Power Engineer setup found. Run `/power-engineer` first to configure preferences.
+
+Then stop.
+
+## Step 2: Read current preferences
+
+Read `.power-engineer/state.json`. Look for the `preferences` object.
+
+If no `preferences` object exists, use defaults:
+- `security_level`: Map from `questionnaire_answers` if available, otherwise `"standard"`
+- `auto_update`: `true`
+
+## Step 3: Present current settings
+
+Use AskUserQuestion to show current preferences and allow changes.
+
+### Security Level
+
+```
+AskUserQuestion:
+  question: "Current security level: [current]. Change to:"
+  header: "Security Level"
+  options:
+    - label: "Standard"
+      description: "Core security review + OWASP + secrets detection"
+    - label: "Enhanced"
+      description: "Standard + headers audit, crypto audit, API security"
+    - label: "Maximum"
+      description: "Enhanced + Bandit SAST, Socket SCA, Docker Scout, test generator, DevSecOps pipeline"
+    - label: "Compliance"
+      description: "Maximum + PCI-DSS audit, mobile security (all 10 new security skills)"
+    - label: "Custom"
+      description: "Cherry-pick from all available security skills"
+    - label: "Keep current"
+      description: "No change"
+  multiSelect: false
+```
+
+### Auto-Update
+
+```
+AskUserQuestion:
+  question: "Auto-update (drift detection on every /power-engineer command):"
+  header: "Auto-Update"
+  options:
+    - label: "Enabled (recommended)"
+      description: "Automatically check for project drift before each run"
+    - label: "Disabled"
+      description: "Only check drift when you explicitly run /power-engineer update"
+  multiSelect: false
+```
+
+## Step 4: Validate and save
+
+Validate `security_level` is one of: standard, enhanced, maximum, compliance, custom.
+
+Write the updated preferences to state.json:
+
+```json
+"preferences": {
+  "security_level": "[selected level]",
+  "auto_update": true|false
+}
+```
+
+## Step 5: Confirm
+
+Show the user:
+```
+Preferences updated:
+  Security level: [level]
+  Auto-update: [enabled|disabled]
+```

--- a/power-engineer/references/flows/help.md
+++ b/power-engineer/references/flows/help.md
@@ -1,0 +1,52 @@
+# Help Flow
+
+Show the user their installed skills with trigger phrases and usage hints.
+
+## Step 1: Check for setup
+
+Check if `.power-engineer/state.json` exists.
+
+If it does not exist, respond with:
+> No Power Engineer setup found. Run `/power-engineer` first to install skills.
+
+Then stop. Do not proceed.
+
+## Step 2: Read installed skills
+
+Read `.power-engineer/state.json` and extract the `installed_skills` array.
+
+If the array is empty, respond with:
+> No skills installed yet. Run `/power-engineer` to set up your skill stack.
+
+Then stop. Do not proceed.
+
+## Step 3: Look up trigger data
+
+For each installed skill, find its entry in the catalog files under
+`references/catalog/`. Read the INDEX.md first, then look up each skill
+in its category file. Extract the `Trigger` and `When to use` columns.
+
+## Step 4: Group and display
+
+Group skills by their catalog category. Display in this format:
+
+```
+Your installed skills:
+
+## Core Methodology
+  /brainstorming         — Before starting any new feature or design
+  /writing-plans         — After brainstorming, to break work into tasks
+  ...
+
+## Security
+  /security-review       — When performing a security review on any codebase
+  ...
+
+[N] skills installed. See .power-engineer/cheatsheet.md for offline reference.
+```
+
+### Notes
+- Only show skills, not MCP servers
+- Only show installed skills (from state.json), not the full catalog
+- The catalog cross-reference is needed because state.json stores skill names
+  and repos, but not trigger/when-to-use data

--- a/power-engineer/references/modules/configurator.md
+++ b/power-engineer/references/modules/configurator.md
@@ -54,8 +54,23 @@ Write `.power-engineer/state.json`:
     "security_level": "standard",
     "auto_update": true
   }
+
 }
 ```
+
+**Setting `security_level` from Q12 answer:**
+
+Map the Q12 security needs answer to a security level preference:
+
+| Q12 answer | security_level |
+|------------|---------------|
+| No additional security / default | `"standard"` |
+| Any single speciality (SAST/DAST, Container & IaC, etc.) | `"enhanced"` |
+| Multiple specialities selected | `"maximum"` |
+| Compliance selected | `"compliance"` |
+| Custom selection | `"custom"` |
+
+If Q12 was not asked (skipped), default to `"standard"`.
 
 ### brand.md
 

--- a/power-engineer/references/modules/configurator.md
+++ b/power-engineer/references/modules/configurator.md
@@ -249,7 +249,43 @@ If the user selects "Yes", append to `.gitignore`:
 .power-engineer/
 ```
 
-## Step 5: Present configuration summary
+## Step 5: Generate cheatsheet
+
+Generate `.power-engineer/cheatsheet.md` as an offline reference for the
+user's installed skills.
+
+For each installed skill in `state.json`, look up its entry in the catalog
+files under `references/catalog/` to get the `Trigger` and `When to use`
+columns. Group the skills by their catalog category.
+
+Write `.power-engineer/cheatsheet.md` in this format:
+
+```markdown
+# Power Engineer Cheatsheet
+
+Generated: [ISO date]
+
+## Core Methodology
+| Trigger | When to use |
+|---------|-------------|
+| /brainstorming | Before starting any new feature or design |
+| /writing-plans | After brainstorming, to break work into tasks |
+
+## Security
+| Trigger | When to use |
+|---------|-------------|
+| /security-review | When performing a security review on any codebase |
+
+---
+[N] skills installed. Run `power engineer help` to see this list in-session.
+```
+
+### Notes
+- Only include skills, not MCP servers
+- Only include skills from the `installed_skills` array in state.json
+- Omit any category section that has no installed skills
+
+## Step 6: Present configuration summary
 
 ```
 Project configured!
@@ -258,6 +294,7 @@ Project configured!
   State directory:     .power-engineer/ created
   Skills patched:      [N] skills received project context
   Brand file:          [created | skipped (no brand info)]
+  Cheatsheet:          .power-engineer/cheatsheet.md
 
   State files:
     .power-engineer/state.json

--- a/power-engineer/references/modules/configurator.md
+++ b/power-engineer/references/modules/configurator.md
@@ -49,6 +49,10 @@ Write `.power-engineer/state.json`:
     "source_file_count": 0,
     "package_json_hash": "[first 8 chars of md5]",
     "dependency_count": 0
+  },
+  "preferences": {
+    "security_level": "standard",
+    "auto_update": true
   }
 }
 ```

--- a/power-engineer/references/modules/drift-detector.md
+++ b/power-engineer/references/modules/drift-detector.md
@@ -9,6 +9,25 @@ reconciliation plan.
 This module requires `.power-engineer/state.json` to exist. If it doesn't,
 report "No previous setup found" and suggest running the full setup.
 
+## Auto-drift check
+
+Before running drift detection, check if auto-drift should run:
+
+1. Read `.power-engineer/state.json`
+2. Check `preferences.auto_update`
+3. If `auto_update` is `false`, skip drift detection unless the user
+   explicitly invoked `/power-engineer update`
+
+**Routes that skip auto-drift check entirely:**
+- help
+- configure
+- status
+- catalog
+
+These routes never trigger drift detection regardless of preferences.
+
+If `preferences` object is missing from state.json, default to `auto_update: true`.
+
 ## Detection checks
 
 ### 1. Dependency changes

--- a/power-engineer/references/modules/skill-resolver.md
+++ b/power-engineer/references/modules/skill-resolver.md
@@ -426,6 +426,62 @@ npx skills@latest add trailofbits/skills --skill insecure-defaults -y
 npx skills@latest add trailofbits/skills --skill sharp-edges -y
 ```
 
+## Security level (from Q12 — new security levels)
+
+Controls which of the 10 new `kalshamsi/claude-security-skills` skills get added.
+These levels are distinct from the existing Q12 branches above.
+
+**Standard:** No new skills added (existing security-review, OWASP, secrets-guardian from core methodology is sufficient)
+
+**Enhanced:** Add exactly these 3:
+```bash
+npx skills@latest add kalshamsi/claude-security-skills --skill security-headers-audit -y
+npx skills@latest add kalshamsi/claude-security-skills --skill crypto-audit -y
+npx skills@latest add kalshamsi/claude-security-skills --skill api-security-tester -y
+```
+
+**Maximum:** Add all of Enhanced + these 5:
+```bash
+npx skills@latest add kalshamsi/claude-security-skills --skill security-headers-audit -y
+npx skills@latest add kalshamsi/claude-security-skills --skill crypto-audit -y
+npx skills@latest add kalshamsi/claude-security-skills --skill api-security-tester -y
+npx skills@latest add kalshamsi/claude-security-skills --skill bandit-sast -y
+npx skills@latest add kalshamsi/claude-security-skills --skill socket-sca -y
+npx skills@latest add kalshamsi/claude-security-skills --skill docker-scout-scanner -y
+npx skills@latest add kalshamsi/claude-security-skills --skill security-test-generator -y
+npx skills@latest add kalshamsi/claude-security-skills --skill devsecops-pipeline -y
+```
+
+**Compliance:** Add all of Maximum + these 2:
+```bash
+npx skills@latest add kalshamsi/claude-security-skills --skill security-headers-audit -y
+npx skills@latest add kalshamsi/claude-security-skills --skill crypto-audit -y
+npx skills@latest add kalshamsi/claude-security-skills --skill api-security-tester -y
+npx skills@latest add kalshamsi/claude-security-skills --skill bandit-sast -y
+npx skills@latest add kalshamsi/claude-security-skills --skill socket-sca -y
+npx skills@latest add kalshamsi/claude-security-skills --skill docker-scout-scanner -y
+npx skills@latest add kalshamsi/claude-security-skills --skill security-test-generator -y
+npx skills@latest add kalshamsi/claude-security-skills --skill devsecops-pipeline -y
+npx skills@latest add kalshamsi/claude-security-skills --skill pci-dss-audit -y
+npx skills@latest add kalshamsi/claude-security-skills --skill mobile-security -y
+```
+
+**Custom:** Present all 10 as options for user to cherry-pick:
+```bash
+npx skills@latest add kalshamsi/claude-security-skills --skill security-headers-audit -y
+npx skills@latest add kalshamsi/claude-security-skills --skill crypto-audit -y
+npx skills@latest add kalshamsi/claude-security-skills --skill api-security-tester -y
+npx skills@latest add kalshamsi/claude-security-skills --skill bandit-sast -y
+npx skills@latest add kalshamsi/claude-security-skills --skill socket-sca -y
+npx skills@latest add kalshamsi/claude-security-skills --skill docker-scout-scanner -y
+npx skills@latest add kalshamsi/claude-security-skills --skill security-test-generator -y
+npx skills@latest add kalshamsi/claude-security-skills --skill devsecops-pipeline -y
+npx skills@latest add kalshamsi/claude-security-skills --skill pci-dss-audit -y
+npx skills@latest add kalshamsi/claude-security-skills --skill mobile-security -y
+```
+
+---
+
 **Framework-specific security (auto-added based on Q3 framework, no question needed):**
 
 If Django detected → also add:

--- a/tests/integration/test-catalog-trigger-maps.sh
+++ b/tests/integration/test-catalog-trigger-maps.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+check() {
+  local name="$1" condition="$2"
+  if eval "$condition"; then
+    echo "  PASS: $name"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: $name"
+    ((FAIL++)) || true
+  fi
+}
+
+CATALOG_DIR="/Users/khalfan/Documents/Development/power-engineer-skills/power-engineer/references/catalog"
+
+echo "=== Test: Catalog Trigger Maps ==="
+echo ""
+
+# --- Part 1: All 16 catalog files have Trigger and When to use columns ---
+
+echo "-- Checking all 16 catalog files have Trigger and When to use columns --"
+echo ""
+
+check "core-methodology.md has Trigger column" \
+  "grep -q '| Trigger |' \"$CATALOG_DIR/core-methodology.md\""
+
+check "core-methodology.md has When to use column" \
+  "grep -q '| When to use |' \"$CATALOG_DIR/core-methodology.md\""
+
+check "anthropic-official.md has Trigger column" \
+  "grep -q '| Trigger |' \"$CATALOG_DIR/anthropic-official.md\""
+
+check "anthropic-official.md has When to use column" \
+  "grep -q '| When to use |' \"$CATALOG_DIR/anthropic-official.md\""
+
+check "engineering/backend-architecture.md has Trigger column" \
+  "grep -q '| Trigger |' \"$CATALOG_DIR/engineering/backend-architecture.md\""
+
+check "engineering/backend-architecture.md has When to use column" \
+  "grep -q '| When to use |' \"$CATALOG_DIR/engineering/backend-architecture.md\""
+
+check "engineering/devops-infra.md has Trigger column" \
+  "grep -q '| Trigger |' \"$CATALOG_DIR/engineering/devops-infra.md\""
+
+check "engineering/devops-infra.md has When to use column" \
+  "grep -q '| When to use |' \"$CATALOG_DIR/engineering/devops-infra.md\""
+
+check "engineering/data-ml.md has Trigger column" \
+  "grep -q '| Trigger |' \"$CATALOG_DIR/engineering/data-ml.md\""
+
+check "engineering/data-ml.md has When to use column" \
+  "grep -q '| When to use |' \"$CATALOG_DIR/engineering/data-ml.md\""
+
+check "engineering/testing-quality.md has Trigger column" \
+  "grep -q '| Trigger |' \"$CATALOG_DIR/engineering/testing-quality.md\""
+
+check "engineering/testing-quality.md has When to use column" \
+  "grep -q '| When to use |' \"$CATALOG_DIR/engineering/testing-quality.md\""
+
+check "engineering/agentic-ai.md has Trigger column" \
+  "grep -q '| Trigger |' \"$CATALOG_DIR/engineering/agentic-ai.md\""
+
+check "engineering/agentic-ai.md has When to use column" \
+  "grep -q '| When to use |' \"$CATALOG_DIR/engineering/agentic-ai.md\""
+
+check "engineering/security-ops.md has Trigger column" \
+  "grep -q '| Trigger |' \"$CATALOG_DIR/engineering/security-ops.md\""
+
+check "engineering/security-ops.md has When to use column" \
+  "grep -q '| When to use |' \"$CATALOG_DIR/engineering/security-ops.md\""
+
+check "frontend/react-next.md has Trigger column" \
+  "grep -q '| Trigger |' \"$CATALOG_DIR/frontend/react-next.md\""
+
+check "frontend/react-next.md has When to use column" \
+  "grep -q '| When to use |' \"$CATALOG_DIR/frontend/react-next.md\""
+
+check "frontend/vue-vite.md has Trigger column" \
+  "grep -q '| Trigger |' \"$CATALOG_DIR/frontend/vue-vite.md\""
+
+check "frontend/vue-vite.md has When to use column" \
+  "grep -q '| When to use |' \"$CATALOG_DIR/frontend/vue-vite.md\""
+
+check "frontend/design-systems.md has Trigger column" \
+  "grep -q '| Trigger |' \"$CATALOG_DIR/frontend/design-systems.md\""
+
+check "frontend/design-systems.md has When to use column" \
+  "grep -q '| When to use |' \"$CATALOG_DIR/frontend/design-systems.md\""
+
+check "frontend/mobile.md has Trigger column" \
+  "grep -q '| Trigger |' \"$CATALOG_DIR/frontend/mobile.md\""
+
+check "frontend/mobile.md has When to use column" \
+  "grep -q '| When to use |' \"$CATALOG_DIR/frontend/mobile.md\""
+
+check "cloud/azure.md has Trigger column" \
+  "grep -q '| Trigger |' \"$CATALOG_DIR/cloud/azure.md\""
+
+check "cloud/azure.md has When to use column" \
+  "grep -q '| When to use |' \"$CATALOG_DIR/cloud/azure.md\""
+
+check "cloud/databases.md has Trigger column" \
+  "grep -q '| Trigger |' \"$CATALOG_DIR/cloud/databases.md\""
+
+check "cloud/databases.md has When to use column" \
+  "grep -q '| When to use |' \"$CATALOG_DIR/cloud/databases.md\""
+
+check "docs-research.md has Trigger column" \
+  "grep -q '| Trigger |' \"$CATALOG_DIR/docs-research.md\""
+
+check "docs-research.md has When to use column" \
+  "grep -q '| When to use |' \"$CATALOG_DIR/docs-research.md\""
+
+check "power-suites.md has Trigger column" \
+  "grep -q '| Trigger |' \"$CATALOG_DIR/power-suites.md\""
+
+check "power-suites.md has When to use column" \
+  "grep -q '| When to use |' \"$CATALOG_DIR/power-suites.md\""
+
+echo ""
+
+# --- Part 2: No skill table row has empty trigger or when-to-use cells ---
+# We detect empty cells by looking for rows that contain "| |" (pipe space pipe),
+# but only in files that have a Trigger column (i.e., all 16 files).
+# We exclude header/separator rows (those containing dashes like |---|).
+
+echo "-- Checking no skill table row has empty Trigger or When to use cells --"
+echo ""
+
+CATALOG_FILES=(
+  "$CATALOG_DIR/core-methodology.md"
+  "$CATALOG_DIR/anthropic-official.md"
+  "$CATALOG_DIR/engineering/backend-architecture.md"
+  "$CATALOG_DIR/engineering/devops-infra.md"
+  "$CATALOG_DIR/engineering/data-ml.md"
+  "$CATALOG_DIR/engineering/testing-quality.md"
+  "$CATALOG_DIR/engineering/agentic-ai.md"
+  "$CATALOG_DIR/engineering/security-ops.md"
+  "$CATALOG_DIR/frontend/react-next.md"
+  "$CATALOG_DIR/frontend/vue-vite.md"
+  "$CATALOG_DIR/frontend/design-systems.md"
+  "$CATALOG_DIR/frontend/mobile.md"
+  "$CATALOG_DIR/cloud/azure.md"
+  "$CATALOG_DIR/cloud/databases.md"
+  "$CATALOG_DIR/docs-research.md"
+  "$CATALOG_DIR/power-suites.md"
+)
+
+for f in "${CATALOG_FILES[@]}"; do
+  fname=$(basename "$f")
+  # Count data rows with empty cells: pipe-space-pipe patterns in non-separator lines
+  empty_count=$(grep -E '^\|' "$f" | grep -v '^\|[-| ]*\|$' | grep -c '| |' || true)
+  check "No empty trigger/when-to-use cells in $fname" \
+    "[ \"$empty_count\" -eq 0 ]"
+done
+
+echo ""
+
+# --- Summary ---
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed"
+echo "================================"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/tests/integration/test-configure-autodrift.sh
+++ b/tests/integration/test-configure-autodrift.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Integration tests for configure flow and auto-drift preference
+# Tests: configure.md exists, state schema has preferences, drift-detector
+#        references auto_update, handles missing preferences, router has configure route
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== Configure Flow + Auto-Drift Tests ==="
+echo ""
+
+# --- Test 1: configure.md file exists ---
+echo "Test 1: configure.md exists"
+if [[ -f "$REPO_ROOT/power-engineer/references/flows/configure.md" ]]; then
+  pass "references/flows/configure.md exists"
+else
+  fail "references/flows/configure.md not found"
+fi
+
+# --- Test 2: configure.md checks for state.json existence ---
+echo "Test 2: configure.md checks for state.json"
+if grep -q "state.json" "$REPO_ROOT/power-engineer/references/flows/configure.md"; then
+  pass "configure.md references state.json"
+else
+  fail "configure.md does not reference state.json"
+fi
+
+# --- Test 3: configure.md handles missing state.json with clear message ---
+echo "Test 3: configure.md handles missing state.json"
+if grep -q "No Power Engineer setup found" "$REPO_ROOT/power-engineer/references/flows/configure.md"; then
+  pass "configure.md has 'No Power Engineer setup found' message"
+else
+  fail "configure.md missing 'No Power Engineer setup found' message"
+fi
+
+# --- Test 4: configure.md reads preferences object ---
+echo "Test 4: configure.md reads preferences"
+if grep -q "preferences" "$REPO_ROOT/power-engineer/references/flows/configure.md"; then
+  pass "configure.md references preferences object"
+else
+  fail "configure.md does not reference preferences object"
+fi
+
+# --- Test 5: configure.md handles missing preferences with defaults ---
+echo "Test 5: configure.md handles missing preferences gracefully"
+if grep -q "no.*preferences\|no \`preferences\`\|no preferences\|If no \`preferences\`" "$REPO_ROOT/power-engineer/references/flows/configure.md"; then
+  pass "configure.md handles missing preferences with defaults"
+else
+  fail "configure.md does not handle missing preferences"
+fi
+
+# --- Test 6: configure.md validates security_level values ---
+echo "Test 6: configure.md validates security_level values"
+if grep -q "standard.*enhanced.*maximum\|Validate.*security_level" "$REPO_ROOT/power-engineer/references/flows/configure.md"; then
+  pass "configure.md validates security_level values"
+else
+  fail "configure.md does not validate security_level values"
+fi
+
+# --- Test 7: configure.md includes all valid security_level options ---
+echo "Test 7: configure.md includes all valid security_level options"
+CONFIGURE_FILE="$REPO_ROOT/power-engineer/references/flows/configure.md"
+if grep -q "standard" "$CONFIGURE_FILE" && \
+   grep -q "enhanced" "$CONFIGURE_FILE" && \
+   grep -q "maximum" "$CONFIGURE_FILE" && \
+   grep -q "compliance" "$CONFIGURE_FILE" && \
+   grep -q "custom" "$CONFIGURE_FILE"; then
+  pass "configure.md includes all valid security_level options"
+else
+  fail "configure.md is missing one or more security_level options"
+fi
+
+# --- Test 8: configure.md includes auto_update option ---
+echo "Test 8: configure.md includes auto_update option"
+if grep -q "auto_update\|Auto-Update\|auto-update" "$REPO_ROOT/power-engineer/references/flows/configure.md"; then
+  pass "configure.md includes auto_update option"
+else
+  fail "configure.md does not include auto_update option"
+fi
+
+# --- Test 9: state schema in configurator.md includes preferences object ---
+echo "Test 9: configurator.md state schema includes preferences object"
+if grep -q '"preferences"' "$REPO_ROOT/power-engineer/references/modules/configurator.md"; then
+  pass "configurator.md state schema includes preferences object"
+else
+  fail "configurator.md state schema missing preferences object"
+fi
+
+# --- Test 10: preferences schema includes security_level ---
+echo "Test 10: configurator.md preferences includes security_level"
+if grep -q '"security_level"' "$REPO_ROOT/power-engineer/references/modules/configurator.md"; then
+  pass "configurator.md preferences includes security_level"
+else
+  fail "configurator.md preferences missing security_level"
+fi
+
+# --- Test 11: preferences schema includes auto_update ---
+echo "Test 11: configurator.md preferences includes auto_update"
+if grep -q '"auto_update"' "$REPO_ROOT/power-engineer/references/modules/configurator.md"; then
+  pass "configurator.md preferences includes auto_update"
+else
+  fail "configurator.md preferences missing auto_update"
+fi
+
+# --- Test 12: preferences default security_level is standard ---
+echo "Test 12: configurator.md preferences default security_level is standard"
+if grep -A 4 '"preferences"' "$REPO_ROOT/power-engineer/references/modules/configurator.md" | \
+   grep -q '"standard"'; then
+  pass "configurator.md default security_level is standard"
+else
+  fail "configurator.md default security_level is not standard"
+fi
+
+# --- Test 13: drift-detector.md references auto_update ---
+echo "Test 13: drift-detector.md references auto_update"
+if grep -q "auto_update" "$REPO_ROOT/power-engineer/references/modules/drift-detector.md"; then
+  pass "drift-detector.md references auto_update"
+else
+  fail "drift-detector.md does not reference auto_update"
+fi
+
+# --- Test 14: drift-detector.md has auto-drift check section ---
+echo "Test 14: drift-detector.md has Auto-drift check section"
+if grep -q "Auto-drift check" "$REPO_ROOT/power-engineer/references/modules/drift-detector.md"; then
+  pass "drift-detector.md has 'Auto-drift check' section"
+else
+  fail "drift-detector.md missing 'Auto-drift check' section"
+fi
+
+# --- Test 15: drift-detector.md skips auto-check for exempt routes ---
+echo "Test 15: drift-detector.md skips auto-check for help, configure, status, catalog"
+DRIFT_FILE="$REPO_ROOT/power-engineer/references/modules/drift-detector.md"
+if grep -q "configure" "$DRIFT_FILE" && \
+   grep -q "help" "$DRIFT_FILE" && \
+   grep -q "status" "$DRIFT_FILE" && \
+   grep -q "catalog" "$DRIFT_FILE"; then
+  pass "drift-detector.md lists exempt routes for auto-drift"
+else
+  fail "drift-detector.md missing one or more exempt routes"
+fi
+
+# --- Test 16: drift-detector.md defaults to auto_update: true when preferences missing ---
+echo "Test 16: drift-detector.md defaults to auto_update true when preferences missing"
+if grep -q "missing.*default\|default.*auto_update: true\|default to \`auto_update: true\`" \
+   "$REPO_ROOT/power-engineer/references/modules/drift-detector.md"; then
+  pass "drift-detector.md defaults to auto_update: true when preferences missing"
+else
+  fail "drift-detector.md does not specify default when preferences missing"
+fi
+
+# --- Test 17: SKILL.md routes "power engineer configure" to configure.md ---
+echo "Test 17: SKILL.md routes 'power engineer configure' to configure.md"
+if grep -q "power engineer configure" "$REPO_ROOT/power-engineer/SKILL.md" && \
+   grep -q "references/flows/configure.md" "$REPO_ROOT/power-engineer/SKILL.md"; then
+  pass "SKILL.md routes 'power engineer configure' to references/flows/configure.md"
+else
+  fail "SKILL.md does not route 'power engineer configure' to configure.md"
+fi
+
+# --- Test 18: configure route is placed after help row ---
+echo "Test 18: configure route is placed after help row"
+HELP_LINE=$(grep -n '| "power engineer help"' "$REPO_ROOT/power-engineer/SKILL.md" | head -1 | cut -d: -f1)
+CONFIGURE_LINE=$(grep -n '| "power engineer configure"' "$REPO_ROOT/power-engineer/SKILL.md" | head -1 | cut -d: -f1)
+if [[ -n "$HELP_LINE" && -n "$CONFIGURE_LINE" && "$CONFIGURE_LINE" -gt "$HELP_LINE" ]]; then
+  pass "configure route (line $CONFIGURE_LINE) is after help row (line $HELP_LINE)"
+else
+  fail "configure route is not correctly ordered after help row"
+fi
+
+# --- Test 19: configure route is placed before the fallback row ---
+echo "Test 19: configure route is before fallback row"
+CONFIGURE_LINE=$(grep -n '| "power engineer configure"' "$REPO_ROOT/power-engineer/SKILL.md" | head -1 | cut -d: -f1)
+FALLBACK_LINE=$(grep -n "anything else" "$REPO_ROOT/power-engineer/SKILL.md" | head -1 | cut -d: -f1)
+if [[ -n "$CONFIGURE_LINE" && -n "$FALLBACK_LINE" && "$CONFIGURE_LINE" -lt "$FALLBACK_LINE" ]]; then
+  pass "configure route (line $CONFIGURE_LINE) is before fallback row (line $FALLBACK_LINE)"
+else
+  fail "configure route is not correctly ordered before fallback row"
+fi
+
+# --- Test 20: SKILL.md line count stays under 60 lines ---
+echo "Test 20: SKILL.md stays under 60 lines"
+LINE_COUNT=$(wc -l < "$REPO_ROOT/power-engineer/SKILL.md")
+if [[ "$LINE_COUNT" -lt 60 ]]; then
+  pass "SKILL.md has $LINE_COUNT lines (under 60)"
+else
+  fail "SKILL.md has $LINE_COUNT lines (exceeds 60 line limit)"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/integration/test-documentation.sh
+++ b/tests/integration/test-documentation.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Integration tests for Phase 6: Documentation + Contributor Guide
+# Tests: README quick-start, CONTRIBUTING.md existence, trigger map fields
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+README="$REPO_ROOT/README.md"
+CONTRIBUTING="$REPO_ROOT/docs/CONTRIBUTING.md"
+INDEX="$REPO_ROOT/power-engineer/references/catalog/INDEX.md"
+
+FAILURES=0
+
+check() {
+  local description="$1"
+  local result="$2"
+  local expected="$3"
+  if echo "$result" | grep -q "$expected"; then
+    echo "PASS: $description"
+  else
+    echo "FAIL: $description"
+    echo "  Expected to find: $expected"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+check_file_exists() {
+  local description="$1"
+  local filepath="$2"
+  if [ -f "$filepath" ]; then
+    echo "PASS: $description"
+  else
+    echo "FAIL: $description — file not found: $filepath"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+echo "=== Documentation tests ==="
+echo ""
+
+# README existence
+check_file_exists "README.md exists" "$README"
+
+# README quick-start section
+readme_content=$(cat "$README")
+check "README has quick-start section" "$readme_content" "Quick start"
+check "README quick-start mentions under 2 minutes" "$readme_content" "under 2 minutes"
+check "README quick-start has 3 steps" "$readme_content" "Step 1"
+check "README quick-start has install step" "$readme_content" "npx skills@latest add"
+check "README quick-start has run step" "$readme_content" "/power-engineer"
+
+# README explainer for beginners
+check "README has beginner explainer section" "$readme_content" "Beginner guide"
+check "README explains what skills are" "$readme_content" "What are Claude Code skills"
+check "README explains what power-engineer does" "$readme_content" "What does Power Engineer do"
+
+# README command reference
+check "README has command reference table" "$readme_content" "Command reference"
+check "README lists power-engineer command" "$readme_content" "power-engineer"
+check "README lists quick command" "$readme_content" "quick"
+check "README lists frontend command" "$readme_content" "frontend"
+check "README lists backend command" "$readme_content" "backend"
+check "README lists devops command" "$readme_content" "devops"
+check "README lists ai command" "$readme_content" "| \`ai\`"
+check "README lists data command" "$readme_content" "| \`data\`"
+check "README lists docs command" "$readme_content" "| \`docs\`"
+check "README lists mobile command" "$readme_content" "| \`mobile\`"
+check "README lists status command" "$readme_content" "| \`status\`"
+check "README lists update command" "$readme_content" "| \`update\`"
+check "README lists catalog command" "$readme_content" "| \`catalog\`"
+check "README lists help command" "$readme_content" "| \`help\`"
+check "README lists configure command" "$readme_content" "| \`configure\`"
+
+# README skill count
+check "README references 290+ skills" "$readme_content" "290+"
+
+# README links to CONTRIBUTING.md
+check "README links to docs/CONTRIBUTING.md" "$readme_content" "docs/CONTRIBUTING.md"
+
+# CONTRIBUTING.md existence
+check_file_exists "docs/CONTRIBUTING.md exists" "$CONTRIBUTING"
+
+# CONTRIBUTING.md catalog contribution section
+contributing_content=$(cat "$CONTRIBUTING")
+check "CONTRIBUTING.md has catalog section" "$contributing_content" "add skills to the catalog"
+check "CONTRIBUTING.md references catalog directory" "$contributing_content" "references/catalog"
+check "CONTRIBUTING.md documents Skill column" "$contributing_content" "Skill"
+check "CONTRIBUTING.md documents Source column" "$contributing_content" "Source"
+check "CONTRIBUTING.md documents Install column" "$contributing_content" "Install"
+check "CONTRIBUTING.md documents Description column" "$contributing_content" "Description"
+check "CONTRIBUTING.md documents Trigger column" "$contributing_content" "Trigger"
+check "CONTRIBUTING.md documents When to use column" "$contributing_content" "When to use"
+check "CONTRIBUTING.md shows trigger format" "$contributing_content" "/skill-name"
+check "CONTRIBUTING.md shows auto trigger" "$contributing_content" "auto"
+check "CONTRIBUTING.md shows install command syntax" "$contributing_content" "npx skills@latest add"
+
+# CONTRIBUTING.md module architecture
+check "CONTRIBUTING.md documents module architecture" "$contributing_content" "Module architecture"
+check "CONTRIBUTING.md documents scanner module" "$contributing_content" "Scanner"
+check "CONTRIBUTING.md documents questionnaire module" "$contributing_content" "Questionnaire"
+check "CONTRIBUTING.md documents skill-resolver module" "$contributing_content" "Skill Resolver"
+check "CONTRIBUTING.md documents installer module" "$contributing_content" "Installer"
+check "CONTRIBUTING.md documents configurator module" "$contributing_content" "Configurator"
+check "CONTRIBUTING.md documents drift-detector module" "$contributing_content" "Drift Detector"
+
+# CONTRIBUTING.md testing requirements
+check "CONTRIBUTING.md documents testing requirements" "$contributing_content" "Testing requirements"
+check "CONTRIBUTING.md uses check() bash pattern" "$contributing_content" "check()"
+check "CONTRIBUTING.md references integration tests dir" "$contributing_content" "tests/integration"
+check "CONTRIBUTING.md documents run-tests command" "$contributing_content" "tests/run-tests.sh"
+
+# CONTRIBUTING.md PR guidelines
+check "CONTRIBUTING.md has PR guidelines" "$contributing_content" "PR guidelines"
+check "CONTRIBUTING.md mentions conventional commits" "$contributing_content" "Conventional Commit"
+check "CONTRIBUTING.md mentions one skill per PR" "$contributing_content" "One skill per PR"
+
+# INDEX.md skill count updated
+index_content=$(cat "$INDEX")
+check "INDEX.md updated to 290+ skills" "$index_content" "290+"
+
+echo ""
+echo "=== Results ==="
+if [ "$FAILURES" -eq 0 ]; then
+  echo "All tests passed."
+else
+  echo "$FAILURES test(s) failed."
+  exit 1
+fi

--- a/tests/integration/test-help-cheatsheet.sh
+++ b/tests/integration/test-help-cheatsheet.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Integration tests for help flow and cheatsheet generator
+# Tests: help.md exists and references state.json, handles missing state.json,
+#        configurator references cheatsheet, router has help route
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+echo "=== Help Flow + Cheatsheet Tests ==="
+echo ""
+
+# --- Test 1: help.md file exists ---
+echo "Test 1: help.md exists"
+if [[ -f "$REPO_ROOT/power-engineer/references/flows/help.md" ]]; then
+  pass "references/flows/help.md exists"
+else
+  fail "references/flows/help.md not found"
+fi
+
+# --- Test 2: help.md references state.json ---
+echo "Test 2: help.md references state.json"
+if grep -q "state.json" "$REPO_ROOT/power-engineer/references/flows/help.md"; then
+  pass "help.md references state.json"
+else
+  fail "help.md does not reference state.json"
+fi
+
+# --- Test 3: help.md handles missing state.json with clear message ---
+echo "Test 3: help.md handles missing state.json"
+if grep -q "No Power Engineer setup found" "$REPO_ROOT/power-engineer/references/flows/help.md"; then
+  pass "help.md has 'No Power Engineer setup found' message"
+else
+  fail "help.md missing 'No Power Engineer setup found' message"
+fi
+
+# --- Test 4: help.md instructs to run /power-engineer first ---
+echo "Test 4: help.md instructs user to run /power-engineer"
+if grep -q "Run \`/power-engineer\` first" "$REPO_ROOT/power-engineer/references/flows/help.md"; then
+  pass "help.md instructs user to run /power-engineer first"
+else
+  fail "help.md does not instruct user to run /power-engineer first"
+fi
+
+# --- Test 5: help.md groups skills by category ---
+echo "Test 5: help.md groups skills by category"
+if grep -q "catalog category" "$REPO_ROOT/power-engineer/references/flows/help.md" || \
+   grep -q "Group" "$REPO_ROOT/power-engineer/references/flows/help.md"; then
+  pass "help.md instructs grouping by category"
+else
+  fail "help.md does not mention grouping by category"
+fi
+
+# --- Test 6: help.md excludes MCP servers ---
+echo "Test 6: help.md excludes MCP servers"
+if grep -q "MCP server" "$REPO_ROOT/power-engineer/references/flows/help.md"; then
+  pass "help.md mentions exclusion of MCP servers"
+else
+  fail "help.md does not mention MCP server exclusion"
+fi
+
+# --- Test 7: configurator.md references cheatsheet generation ---
+echo "Test 7: configurator.md references cheatsheet generation"
+if grep -q "cheatsheet.md" "$REPO_ROOT/power-engineer/references/modules/configurator.md"; then
+  pass "configurator.md references cheatsheet.md"
+else
+  fail "configurator.md does not reference cheatsheet.md"
+fi
+
+# --- Test 8: configurator.md has Step 5 as cheatsheet step ---
+echo "Test 8: configurator.md Step 5 is cheatsheet generation"
+if grep -q "Step 5: Generate cheatsheet" "$REPO_ROOT/power-engineer/references/modules/configurator.md"; then
+  pass "configurator.md Step 5 is 'Generate cheatsheet'"
+else
+  fail "configurator.md Step 5 is not 'Generate cheatsheet'"
+fi
+
+# --- Test 9: configurator.md has Step 6 as summary ---
+echo "Test 9: configurator.md Step 6 is configuration summary"
+if grep -q "Step 6: Present configuration summary" "$REPO_ROOT/power-engineer/references/modules/configurator.md"; then
+  pass "configurator.md Step 6 is 'Present configuration summary'"
+else
+  fail "configurator.md Step 6 is not 'Present configuration summary'"
+fi
+
+# --- Test 10: post-install summary mentions cheatsheet file location ---
+echo "Test 10: post-install summary mentions cheatsheet location"
+if grep -A 20 "Step 6: Present configuration summary" "$REPO_ROOT/power-engineer/references/modules/configurator.md" | \
+   grep -q "cheatsheet"; then
+  pass "post-install summary mentions cheatsheet"
+else
+  fail "post-install summary does not mention cheatsheet"
+fi
+
+# --- Test 11: cheatsheet contains only installed skills (not full catalog) ---
+echo "Test 11: configurator cheatsheet uses installed_skills from state.json"
+if grep -q "installed_skills" "$REPO_ROOT/power-engineer/references/modules/configurator.md" || \
+   grep -q "state.json" "$REPO_ROOT/power-engineer/references/modules/configurator.md"; then
+  pass "configurator cheatsheet references state.json installed_skills"
+else
+  fail "configurator cheatsheet does not reference state.json"
+fi
+
+# --- Test 12: SKILL.md routes "power engineer help" to help.md ---
+echo "Test 12: SKILL.md routes 'power engineer help' to help.md"
+if grep -q "power engineer help" "$REPO_ROOT/power-engineer/SKILL.md" && \
+   grep -q "references/flows/help.md" "$REPO_ROOT/power-engineer/SKILL.md"; then
+  pass "SKILL.md routes 'power engineer help' to references/flows/help.md"
+else
+  fail "SKILL.md does not route 'power engineer help' to help.md"
+fi
+
+# --- Test 13: help route is placed before the fallback row ---
+echo "Test 13: help route is placed before the fallback row"
+HELP_LINE=$(grep -n "power engineer help" "$REPO_ROOT/power-engineer/SKILL.md" | cut -d: -f1)
+FALLBACK_LINE=$(grep -n "anything else" "$REPO_ROOT/power-engineer/SKILL.md" | cut -d: -f1)
+if [[ -n "$HELP_LINE" && -n "$FALLBACK_LINE" && "$HELP_LINE" -lt "$FALLBACK_LINE" ]]; then
+  pass "help route (line $HELP_LINE) is before fallback row (line $FALLBACK_LINE)"
+else
+  fail "help route is not correctly ordered before fallback row"
+fi
+
+# --- Test 14: SKILL.md line count stays under 55 lines ---
+echo "Test 14: SKILL.md stays under 55 lines"
+LINE_COUNT=$(wc -l < "$REPO_ROOT/power-engineer/SKILL.md")
+if [[ "$LINE_COUNT" -lt 55 ]]; then
+  pass "SKILL.md has $LINE_COUNT lines (under 55)"
+else
+  fail "SKILL.md has $LINE_COUNT lines (exceeds 55 line limit)"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi

--- a/tests/integration/test-security-resolver-wiring.sh
+++ b/tests/integration/test-security-resolver-wiring.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+check() {
+  local name="$1" condition="$2"
+  if eval "$condition"; then
+    echo "  PASS: $name"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: $name"
+    ((FAIL++)) || true
+  fi
+}
+
+RESOLVER="/Users/khalfan/Documents/Development/power-engineer-skills/power-engineer/references/modules/skill-resolver.md"
+
+echo "=== Test: Security Resolver Wiring — Phase 2b Integration ==="
+echo ""
+
+# --- Part 1: New security level section exists ---
+
+echo "-- Checking new security level section exists --"
+echo ""
+
+check "new security level section heading present" \
+  "grep -q '## Security level (from Q12 — new security levels)' \"$RESOLVER\""
+
+check "Standard branch present" \
+  "grep -q '\*\*Standard:\*\*' \"$RESOLVER\""
+
+check "Enhanced branch present" \
+  "grep -q '\*\*Enhanced:\*\*' \"$RESOLVER\""
+
+check "Maximum branch present" \
+  "grep -q '\*\*Maximum:\*\*' \"$RESOLVER\""
+
+check "Compliance branch present" \
+  "grep -q '\*\*Compliance:\*\*' \"$RESOLVER\""
+
+check "Custom branch present" \
+  "grep -q '\*\*Custom:\*\*' \"$RESOLVER\""
+
+echo ""
+
+# --- Part 2: Standard branch adds no new skills ---
+
+echo "-- Verifying Standard branch adds no kalshamsi skills --"
+echo ""
+
+check "Standard branch does not install kalshamsi skills (no npx command in Standard paragraph)" \
+  "awk '/\*\*Standard:\*\*/,/\*\*Enhanced:\*\*/' \"$RESOLVER\" | grep -v 'npx skills@latest add kalshamsi' > /dev/null && ! awk '/\*\*Standard:\*\*/,/\*\*Enhanced:\*\*/' \"$RESOLVER\" | grep -q 'npx skills@latest add kalshamsi'"
+
+echo ""
+
+# --- Part 3: Enhanced branch maps exactly 3 skills ---
+
+echo "-- Verifying Enhanced branch maps exactly 3 skills --"
+echo ""
+
+check "Enhanced includes security-headers-audit" \
+  "awk '/\*\*Enhanced:\*\*/,/\*\*Maximum:\*\*/' \"$RESOLVER\" | grep -q 'security-headers-audit'"
+
+check "Enhanced includes crypto-audit" \
+  "awk '/\*\*Enhanced:\*\*/,/\*\*Maximum:\*\*/' \"$RESOLVER\" | grep -q 'crypto-audit'"
+
+check "Enhanced includes api-security-tester" \
+  "awk '/\*\*Enhanced:\*\*/,/\*\*Maximum:\*\*/' \"$RESOLVER\" | grep -q 'api-security-tester'"
+
+check "Enhanced does NOT include bandit-sast" \
+  "! awk '/\*\*Enhanced:\*\*/,/\*\*Maximum:\*\*/' \"$RESOLVER\" | grep -q 'bandit-sast'"
+
+check "Enhanced does NOT include socket-sca" \
+  "! awk '/\*\*Enhanced:\*\*/,/\*\*Maximum:\*\*/' \"$RESOLVER\" | grep -q 'socket-sca'"
+
+check "Enhanced does NOT include docker-scout-scanner" \
+  "! awk '/\*\*Enhanced:\*\*/,/\*\*Maximum:\*\*/' \"$RESOLVER\" | grep -q 'docker-scout-scanner'"
+
+check "Enhanced does NOT include pci-dss-audit" \
+  "! awk '/\*\*Enhanced:\*\*/,/\*\*Maximum:\*\*/' \"$RESOLVER\" | grep -q 'pci-dss-audit'"
+
+check "Enhanced does NOT include mobile-security" \
+  "! awk '/\*\*Enhanced:\*\*/,/\*\*Maximum:\*\*/' \"$RESOLVER\" | grep -q 'mobile-security'"
+
+echo ""
+
+# --- Part 4: Maximum branch maps Enhanced + 5 ---
+
+echo "-- Verifying Maximum branch maps Enhanced skills + 5 additional --"
+echo ""
+
+check "Maximum includes security-headers-audit" \
+  "awk '/\*\*Maximum:\*\*/,/\*\*Compliance:\*\*/' \"$RESOLVER\" | grep -q 'security-headers-audit'"
+
+check "Maximum includes crypto-audit" \
+  "awk '/\*\*Maximum:\*\*/,/\*\*Compliance:\*\*/' \"$RESOLVER\" | grep -q 'crypto-audit'"
+
+check "Maximum includes api-security-tester" \
+  "awk '/\*\*Maximum:\*\*/,/\*\*Compliance:\*\*/' \"$RESOLVER\" | grep -q 'api-security-tester'"
+
+check "Maximum includes bandit-sast" \
+  "awk '/\*\*Maximum:\*\*/,/\*\*Compliance:\*\*/' \"$RESOLVER\" | grep -q 'bandit-sast'"
+
+check "Maximum includes socket-sca" \
+  "awk '/\*\*Maximum:\*\*/,/\*\*Compliance:\*\*/' \"$RESOLVER\" | grep -q 'socket-sca'"
+
+check "Maximum includes docker-scout-scanner" \
+  "awk '/\*\*Maximum:\*\*/,/\*\*Compliance:\*\*/' \"$RESOLVER\" | grep -q 'docker-scout-scanner'"
+
+check "Maximum includes security-test-generator" \
+  "awk '/\*\*Maximum:\*\*/,/\*\*Compliance:\*\*/' \"$RESOLVER\" | grep -q 'security-test-generator'"
+
+check "Maximum includes devsecops-pipeline" \
+  "awk '/\*\*Maximum:\*\*/,/\*\*Compliance:\*\*/' \"$RESOLVER\" | grep -q 'devsecops-pipeline'"
+
+check "Maximum does NOT include pci-dss-audit" \
+  "! awk '/\*\*Maximum:\*\*/,/\*\*Compliance:\*\*/' \"$RESOLVER\" | grep -q 'pci-dss-audit'"
+
+check "Maximum does NOT include mobile-security" \
+  "! awk '/\*\*Maximum:\*\*/,/\*\*Compliance:\*\*/' \"$RESOLVER\" | grep -q 'mobile-security'"
+
+echo ""
+
+# --- Part 5: Compliance branch maps Maximum + 2 ---
+
+echo "-- Verifying Compliance branch maps Maximum skills + pci-dss-audit + mobile-security --"
+echo ""
+
+check "Compliance includes security-headers-audit" \
+  "awk '/\*\*Compliance:\*\*/,/\*\*Custom:\*\*/' \"$RESOLVER\" | grep -q 'security-headers-audit'"
+
+check "Compliance includes crypto-audit" \
+  "awk '/\*\*Compliance:\*\*/,/\*\*Custom:\*\*/' \"$RESOLVER\" | grep -q 'crypto-audit'"
+
+check "Compliance includes api-security-tester" \
+  "awk '/\*\*Compliance:\*\*/,/\*\*Custom:\*\*/' \"$RESOLVER\" | grep -q 'api-security-tester'"
+
+check "Compliance includes bandit-sast" \
+  "awk '/\*\*Compliance:\*\*/,/\*\*Custom:\*\*/' \"$RESOLVER\" | grep -q 'bandit-sast'"
+
+check "Compliance includes socket-sca" \
+  "awk '/\*\*Compliance:\*\*/,/\*\*Custom:\*\*/' \"$RESOLVER\" | grep -q 'socket-sca'"
+
+check "Compliance includes docker-scout-scanner" \
+  "awk '/\*\*Compliance:\*\*/,/\*\*Custom:\*\*/' \"$RESOLVER\" | grep -q 'docker-scout-scanner'"
+
+check "Compliance includes security-test-generator" \
+  "awk '/\*\*Compliance:\*\*/,/\*\*Custom:\*\*/' \"$RESOLVER\" | grep -q 'security-test-generator'"
+
+check "Compliance includes devsecops-pipeline" \
+  "awk '/\*\*Compliance:\*\*/,/\*\*Custom:\*\*/' \"$RESOLVER\" | grep -q 'devsecops-pipeline'"
+
+check "Compliance includes pci-dss-audit" \
+  "awk '/\*\*Compliance:\*\*/,/\*\*Custom:\*\*/' \"$RESOLVER\" | grep -q 'pci-dss-audit'"
+
+check "Compliance includes mobile-security" \
+  "awk '/\*\*Compliance:\*\*/,/\*\*Custom:\*\*/' \"$RESOLVER\" | grep -q 'mobile-security'"
+
+echo ""
+
+# --- Part 6: Custom branch lists all 10 ---
+
+echo "-- Verifying Custom branch lists all 10 skills --"
+echo ""
+
+check "Custom includes security-headers-audit" \
+  "awk '/\*\*Custom:\*\*/,/^---/' \"$RESOLVER\" | grep -q 'security-headers-audit'"
+
+check "Custom includes crypto-audit" \
+  "awk '/\*\*Custom:\*\*/,/^---/' \"$RESOLVER\" | grep -q 'crypto-audit'"
+
+check "Custom includes api-security-tester" \
+  "awk '/\*\*Custom:\*\*/,/^---/' \"$RESOLVER\" | grep -q 'api-security-tester'"
+
+check "Custom includes bandit-sast" \
+  "awk '/\*\*Custom:\*\*/,/^---/' \"$RESOLVER\" | grep -q 'bandit-sast'"
+
+check "Custom includes socket-sca" \
+  "awk '/\*\*Custom:\*\*/,/^---/' \"$RESOLVER\" | grep -q 'socket-sca'"
+
+check "Custom includes docker-scout-scanner" \
+  "awk '/\*\*Custom:\*\*/,/^---/' \"$RESOLVER\" | grep -q 'docker-scout-scanner'"
+
+check "Custom includes security-test-generator" \
+  "awk '/\*\*Custom:\*\*/,/^---/' \"$RESOLVER\" | grep -q 'security-test-generator'"
+
+check "Custom includes devsecops-pipeline" \
+  "awk '/\*\*Custom:\*\*/,/^---/' \"$RESOLVER\" | grep -q 'devsecops-pipeline'"
+
+check "Custom includes pci-dss-audit" \
+  "awk '/\*\*Custom:\*\*/,/^---/' \"$RESOLVER\" | grep -q 'pci-dss-audit'"
+
+check "Custom includes mobile-security" \
+  "awk '/\*\*Custom:\*\*/,/^---/' \"$RESOLVER\" | grep -q 'mobile-security'"
+
+echo ""
+
+# --- Part 7: No duplicate skill entries within each branch ---
+
+echo "-- Verifying no duplicate skill entries in the new section --"
+echo ""
+
+check "No duplicate security-headers-audit in Enhanced block" \
+  "[ \$(awk '/\*\*Enhanced:\*\*/,/\*\*Maximum:\*\*/' \"$RESOLVER\" | grep -c 'security-headers-audit') -le 1 ]"
+
+check "No duplicate bandit-sast in Maximum block" \
+  "[ \$(awk '/\*\*Maximum:\*\*/,/\*\*Compliance:\*\*/' \"$RESOLVER\" | grep -c 'bandit-sast') -le 1 ]"
+
+check "No duplicate pci-dss-audit in Compliance block" \
+  "[ \$(awk '/\*\*Compliance:\*\*/,/\*\*Custom:\*\*/' \"$RESOLVER\" | grep -c 'pci-dss-audit') -le 1 ]"
+
+check "No duplicate mobile-security in Custom block" \
+  "[ \$(awk '/\*\*Custom:\*\*/,/^---/' \"$RESOLVER\" | grep -c 'mobile-security') -le 1 ]"
+
+echo ""
+
+# --- Part 8: All 10 skills referenced somewhere in resolver ---
+
+echo "-- Verifying all 10 new skills are referenced in the resolver --"
+echo ""
+
+check "resolver references security-headers-audit" \
+  "grep -q 'security-headers-audit' \"$RESOLVER\""
+
+check "resolver references crypto-audit" \
+  "grep -q 'crypto-audit' \"$RESOLVER\""
+
+check "resolver references api-security-tester" \
+  "grep -q 'api-security-tester' \"$RESOLVER\""
+
+check "resolver references bandit-sast" \
+  "grep -q 'bandit-sast' \"$RESOLVER\""
+
+check "resolver references socket-sca" \
+  "grep -q 'socket-sca' \"$RESOLVER\""
+
+check "resolver references docker-scout-scanner" \
+  "grep -q 'docker-scout-scanner' \"$RESOLVER\""
+
+check "resolver references security-test-generator" \
+  "grep -q 'security-test-generator' \"$RESOLVER\""
+
+check "resolver references devsecops-pipeline" \
+  "grep -q 'devsecops-pipeline' \"$RESOLVER\""
+
+check "resolver references pci-dss-audit" \
+  "grep -q 'pci-dss-audit' \"$RESOLVER\""
+
+check "resolver references mobile-security" \
+  "grep -q 'mobile-security' \"$RESOLVER\""
+
+echo ""
+
+# --- Summary ---
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+echo ""
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/tests/integration/test-security-skills-catalog.sh
+++ b/tests/integration/test-security-skills-catalog.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+check() {
+  local name="$1" condition="$2"
+  if eval "$condition"; then
+    echo "  PASS: $name"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: $name"
+    ((FAIL++)) || true
+  fi
+}
+
+SECURITY_OPS="/Users/khalfan/Documents/Development/power-engineer-skills/power-engineer/references/catalog/engineering/security-ops.md"
+
+echo "=== Test: Security Skills Catalog — Phase 2a Integration ==="
+echo ""
+
+# --- Part 1: All 10 new skills are present ---
+
+echo "-- Checking all 10 new skills are present in security-ops.md --"
+echo ""
+
+check "bandit-sast skill row present" \
+  "grep -q '| bandit-sast |' \"$SECURITY_OPS\""
+
+check "crypto-audit skill row present" \
+  "grep -q '| crypto-audit |' \"$SECURITY_OPS\""
+
+check "security-test-generator skill row present" \
+  "grep -q '| security-test-generator |' \"$SECURITY_OPS\""
+
+check "devsecops-pipeline skill row present" \
+  "grep -q '| devsecops-pipeline |' \"$SECURITY_OPS\""
+
+check "socket-sca skill row present" \
+  "grep -q '| socket-sca |' \"$SECURITY_OPS\""
+
+check "docker-scout-scanner skill row present" \
+  "grep -q '| docker-scout-scanner |' \"$SECURITY_OPS\""
+
+check "security-headers-audit skill row present" \
+  "grep -q '| security-headers-audit |' \"$SECURITY_OPS\""
+
+check "api-security-tester skill row present" \
+  "grep -q '| api-security-tester |' \"$SECURITY_OPS\""
+
+check "mobile-security skill row present" \
+  "grep -q '| mobile-security |' \"$SECURITY_OPS\""
+
+check "pci-dss-audit skill row present" \
+  "grep -q '| pci-dss-audit |' \"$SECURITY_OPS\""
+
+echo ""
+
+# --- Part 2: Install command syntax validation ---
+
+echo "-- Validating install command syntax for all 10 new skills --"
+echo ""
+
+check "bandit-sast install command uses correct syntax" \
+  "grep -q 'npx skills@latest add kalshamsi/claude-security-skills --skill bandit-sast -y' \"$SECURITY_OPS\""
+
+check "crypto-audit install command uses correct syntax" \
+  "grep -q 'npx skills@latest add kalshamsi/claude-security-skills --skill crypto-audit -y' \"$SECURITY_OPS\""
+
+check "security-test-generator install command uses correct syntax" \
+  "grep -q 'npx skills@latest add kalshamsi/claude-security-skills --skill security-test-generator -y' \"$SECURITY_OPS\""
+
+check "devsecops-pipeline install command uses correct syntax" \
+  "grep -q 'npx skills@latest add kalshamsi/claude-security-skills --skill devsecops-pipeline -y' \"$SECURITY_OPS\""
+
+check "socket-sca install command uses correct syntax" \
+  "grep -q 'npx skills@latest add kalshamsi/claude-security-skills --skill socket-sca -y' \"$SECURITY_OPS\""
+
+check "docker-scout-scanner install command uses correct syntax" \
+  "grep -q 'npx skills@latest add kalshamsi/claude-security-skills --skill docker-scout-scanner -y' \"$SECURITY_OPS\""
+
+check "security-headers-audit install command uses correct syntax" \
+  "grep -q 'npx skills@latest add kalshamsi/claude-security-skills --skill security-headers-audit -y' \"$SECURITY_OPS\""
+
+check "api-security-tester install command uses correct syntax" \
+  "grep -q 'npx skills@latest add kalshamsi/claude-security-skills --skill api-security-tester -y' \"$SECURITY_OPS\""
+
+check "mobile-security install command uses correct syntax" \
+  "grep -q 'npx skills@latest add kalshamsi/claude-security-skills --skill mobile-security -y' \"$SECURITY_OPS\""
+
+check "pci-dss-audit install command uses correct syntax" \
+  "grep -q 'npx skills@latest add kalshamsi/claude-security-skills --skill pci-dss-audit -y' \"$SECURITY_OPS\""
+
+echo ""
+
+# --- Part 3: Trigger and When-to-use populated for each new skill ---
+
+echo "-- Confirming Trigger and When-to-use are populated for new skills --"
+echo ""
+
+check "bandit-sast has trigger /bandit-sast" \
+  "grep -q '/bandit-sast' \"$SECURITY_OPS\""
+
+check "crypto-audit has trigger /crypto-audit" \
+  "grep -q '/crypto-audit' \"$SECURITY_OPS\""
+
+check "security-test-generator has trigger /security-test-generator" \
+  "grep -q '/security-test-generator' \"$SECURITY_OPS\""
+
+check "devsecops-pipeline has trigger /devsecops-pipeline" \
+  "grep -q '/devsecops-pipeline' \"$SECURITY_OPS\""
+
+check "socket-sca has trigger /socket-sca" \
+  "grep -q '/socket-sca' \"$SECURITY_OPS\""
+
+check "docker-scout-scanner has trigger /docker-scout-scanner" \
+  "grep -q '/docker-scout-scanner' \"$SECURITY_OPS\""
+
+check "security-headers-audit has trigger /security-headers-audit" \
+  "grep -q '/security-headers-audit' \"$SECURITY_OPS\""
+
+check "api-security-tester has trigger /api-security-tester" \
+  "grep -q '/api-security-tester' \"$SECURITY_OPS\""
+
+check "mobile-security has trigger /mobile-security" \
+  "grep -q '/mobile-security' \"$SECURITY_OPS\""
+
+check "pci-dss-audit has trigger /pci-dss-audit" \
+  "grep -q '/pci-dss-audit' \"$SECURITY_OPS\""
+
+echo ""
+
+# --- Part 4: New section exists and is correctly placed ---
+
+echo "-- Verifying new Security Testing & Analysis section placement --"
+echo ""
+
+check "Security Testing & Analysis section exists" \
+  "grep -q '## Security Testing & Analysis' \"$SECURITY_OPS\""
+
+check "Security Testing & Analysis section appears before Multi-Tool / Comprehensive" \
+  "awk '/## Security Testing & Analysis/{sa=NR} /## Multi-Tool \/ Comprehensive/{mb=NR} END{exit !(sa > 0 && mb > 0 && sa < mb)}' \"$SECURITY_OPS\""
+
+check "Security Testing & Analysis section appears after Framework-Specific Security" \
+  "awk '/## Framework-Specific Security/{fs=NR} /## Security Testing & Analysis/{sa=NR} END{exit !(fs > 0 && sa > 0 && fs < sa)}' \"$SECURITY_OPS\""
+
+echo ""
+
+# --- Part 5: Section placement of skills in existing sections ---
+
+echo "-- Verifying 4 skills are in their correct existing sections --"
+echo ""
+
+check "bandit-sast appears in SAST section" \
+  "awk '/## SAST/,/^---/' \"$SECURITY_OPS\" | grep -q 'bandit-sast'"
+
+check "socket-sca appears in SCA section" \
+  "awk '/## SCA/,/^---/' \"$SECURITY_OPS\" | grep -q 'socket-sca'"
+
+check "docker-scout-scanner appears in Container Security section" \
+  "awk '/## Container Security/,/^---/' \"$SECURITY_OPS\" | grep -q 'docker-scout-scanner'"
+
+check "pci-dss-audit appears in Compliance section" \
+  "awk '/## Compliance/,/^---/' \"$SECURITY_OPS\" | grep -q 'pci-dss-audit'"
+
+echo ""
+
+# --- Summary ---
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+echo ""
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/tests/integration/test-stable-api.sh
+++ b/tests/integration/test-stable-api.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# tests/integration/test-stable-api.sh
+# Phase 5: Stable API Validation — verifies all 14 commands are routed in SKILL.md
+# and that each target file exists on disk.
+
+set -euo pipefail
+
+SKILL_MD="/Users/khalfan/Documents/Development/power-engineer-skills/power-engineer/SKILL.md"
+BASE_DIR="/Users/khalfan/Documents/Development/power-engineer-skills/power-engineer"
+
+PASS=0
+FAIL=0
+
+check() {
+  local description="$1"
+  local result="$2"
+  if [ "$result" = "pass" ]; then
+    echo "  PASS: $description"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $description"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo ""
+echo "=== Phase 5: Stable API Validation ==="
+echo ""
+
+echo "--- Route presence in SKILL.md ---"
+
+# 1. power-engineer (full interview)
+grep -q "full-interview.md" "$SKILL_MD" && check "power-engineer -> full-interview.md route present" "pass" || check "power-engineer -> full-interview.md route present" "fail"
+
+# 2. quick
+grep -q "quick.md" "$SKILL_MD" && check "quick -> quick.md route present" "pass" || check "quick -> quick.md route present" "fail"
+
+# 3. frontend
+grep -q "frontend.md" "$SKILL_MD" && check "frontend -> frontend.md route present" "pass" || check "frontend -> frontend.md route present" "fail"
+
+# 4. backend
+grep -q "backend.md" "$SKILL_MD" && check "backend -> backend.md route present" "pass" || check "backend -> backend.md route present" "fail"
+
+# 5. devops
+grep -q "devops.md" "$SKILL_MD" && check "devops -> devops.md route present" "pass" || check "devops -> devops.md route present" "fail"
+
+# 6. ai
+grep -q "flows/ai.md" "$SKILL_MD" && check "ai -> ai.md route present" "pass" || check "ai -> ai.md route present" "fail"
+
+# 7. data
+grep -q "data.md" "$SKILL_MD" && check "data -> data.md route present" "pass" || check "data -> data.md route present" "fail"
+
+# 8. docs
+grep -q "flows/docs.md" "$SKILL_MD" && check "docs -> docs.md route present" "pass" || check "docs -> docs.md route present" "fail"
+
+# 9. mobile
+grep -q "mobile.md" "$SKILL_MD" && check "mobile -> mobile.md route present" "pass" || check "mobile -> mobile.md route present" "fail"
+
+# 10. status
+grep -q "drift-detector.md" "$SKILL_MD" && check "status -> drift-detector.md route present" "pass" || check "status -> drift-detector.md route present" "fail"
+
+# 11. update
+grep -q "update.md" "$SKILL_MD" && check "update -> update.md route present" "pass" || check "update -> update.md route present" "fail"
+
+# 12. catalog
+grep -q "catalog-browse.md" "$SKILL_MD" && check "catalog -> catalog-browse.md route present" "pass" || check "catalog -> catalog-browse.md route present" "fail"
+
+# 13. help
+grep -q "help.md" "$SKILL_MD" && check "help -> help.md route present" "pass" || check "help -> help.md route present" "fail"
+
+# 14. configure
+grep -q "configure.md" "$SKILL_MD" && check "configure -> configure.md route present" "pass" || check "configure -> configure.md route present" "fail"
+
+echo ""
+echo "--- Target file existence ---"
+
+# 1. full-interview.md
+[ -f "$BASE_DIR/references/flows/full-interview.md" ] && check "references/flows/full-interview.md exists" "pass" || check "references/flows/full-interview.md exists" "fail"
+
+# 2. quick.md
+[ -f "$BASE_DIR/references/flows/quick.md" ] && check "references/flows/quick.md exists" "pass" || check "references/flows/quick.md exists" "fail"
+
+# 3. frontend.md
+[ -f "$BASE_DIR/references/flows/frontend.md" ] && check "references/flows/frontend.md exists" "pass" || check "references/flows/frontend.md exists" "fail"
+
+# 4. backend.md
+[ -f "$BASE_DIR/references/flows/backend.md" ] && check "references/flows/backend.md exists" "pass" || check "references/flows/backend.md exists" "fail"
+
+# 5. devops.md
+[ -f "$BASE_DIR/references/flows/devops.md" ] && check "references/flows/devops.md exists" "pass" || check "references/flows/devops.md exists" "fail"
+
+# 6. ai.md
+[ -f "$BASE_DIR/references/flows/ai.md" ] && check "references/flows/ai.md exists" "pass" || check "references/flows/ai.md exists" "fail"
+
+# 7. data.md
+[ -f "$BASE_DIR/references/flows/data.md" ] && check "references/flows/data.md exists" "pass" || check "references/flows/data.md exists" "fail"
+
+# 8. docs.md
+[ -f "$BASE_DIR/references/flows/docs.md" ] && check "references/flows/docs.md exists" "pass" || check "references/flows/docs.md exists" "fail"
+
+# 9. mobile.md
+[ -f "$BASE_DIR/references/flows/mobile.md" ] && check "references/flows/mobile.md exists" "pass" || check "references/flows/mobile.md exists" "fail"
+
+# 10. drift-detector.md
+[ -f "$BASE_DIR/references/modules/drift-detector.md" ] && check "references/modules/drift-detector.md exists" "pass" || check "references/modules/drift-detector.md exists" "fail"
+
+# 11. update.md
+[ -f "$BASE_DIR/references/flows/update.md" ] && check "references/flows/update.md exists" "pass" || check "references/flows/update.md exists" "fail"
+
+# 12. catalog-browse.md
+[ -f "$BASE_DIR/references/flows/catalog-browse.md" ] && check "references/flows/catalog-browse.md exists" "pass" || check "references/flows/catalog-browse.md exists" "fail"
+
+# 13. help.md
+[ -f "$BASE_DIR/references/flows/help.md" ] && check "references/flows/help.md exists" "pass" || check "references/flows/help.md exists" "fail"
+
+# 14. configure.md
+[ -f "$BASE_DIR/references/flows/configure.md" ] && check "references/flows/configure.md exists" "pass" || check "references/flows/configure.md exists" "fail"
+
+echo ""
+echo "--- No orphaned routes check ---"
+
+# Extract all references/... .md paths from the router table and verify each exists
+REFS=$(grep -oE 'references/[^`]+\.md' "$SKILL_MD" | sort -u)
+for ref in $REFS; do
+  if [ -f "$BASE_DIR/$ref" ]; then
+    check "No orphan: $ref" "pass"
+  else
+    check "No orphan: $ref" "fail"
+  fi
+done
+
+echo ""
+echo "=============================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "=============================="
+echo ""
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Production-ready v1.0.0 release implementing all 6 phases from the PRD:

- **Trigger maps**: Added `Trigger` and `When to use` columns to all 16 catalog files (280+ skills)
- **Security skills**: 10 new skills from `kalshamsi/claude-security-skills` added to catalog and wired into Q12 resolver with 5 security levels (Standard/Enhanced/Maximum/Compliance/Custom)
- **Help command**: New `/power-engineer help` shows installed skills grouped by category with trigger phrases
- **Cheatsheet**: Auto-generated `.power-engineer/cheatsheet.md` after installation
- **Configure command**: New `/power-engineer configure` for security level and auto-update preferences
- **Auto-drift**: Drift detection respects `preferences.auto_update` and skips exempt routes
- **Stable API**: All 14 commands validated and locked
- **Documentation**: README rewritten for dual audiences (power users + beginners), CONTRIBUTING.md added, skill count updated to 290+

### Files changed

- 16 catalog files (Trigger/When-to-use columns)
- 2 new flows: `help.md`, `configure.md`
- 3 modified modules: `configurator.md`, `drift-detector.md`, `skill-resolver.md`
- Router: `SKILL.md` (2 new routes)
- Docs: `README.md` (rewrite), `docs/CONTRIBUTING.md` (new), `INDEX.md` (290+)
- 7 new test files, 312 total tests passing

## Test plan

- [x] All 8 test suites pass (312 tests, 0 failures)
- [x] Original `run-tests.sh` still passes (39/39) — no regressions
- [x] Phase 1: All 16 catalog files have Trigger/When-to-use columns (48 tests)
- [x] Phase 2a: All 10 security skills present with correct format (37 tests)
- [x] Phase 2b: Q12 levels map to correct skill sets (59 tests)
- [x] Phase 3: Help flow + cheatsheet generation (14 tests)
- [x] Phase 4: Configure flow + auto-drift (20 tests)
- [x] Phase 5: All 14 routes present and target files exist (42 tests)
- [x] Phase 6: README + CONTRIBUTING.md meet all criteria (53 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)