### PR TITLE
v1.4.1 — Hook-script hardening (security-review follow-ups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to Power Engineer are documented in this file.
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.4.1] — 2026-04-18
+
+### Added
+- Stderr warning at hook start when `.power-engineer/memory-errors.log` contains prior entries — operator-observability surface for silent hook failures (addresses v1.4.0 security review ⚠️ MINOR #2)
+
+### Changed
+- `power-engineer/scripts/hooks/session-end-handoff.sh` and `power-engineer/scripts/hooks/pre-compact-snapshot.sh` output filenames now include process ID (`$$`) alongside the UTC second-resolution timestamp — prevents filename collision on sub-second concurrent invocations (addresses v1.4.0 security review ⚠️ MINOR #1)
+
+### Catalog
+- **Catalog version:** 1.4.0 (unchanged)
+- **Skills added:** none
+- **Skills removed:** none
+- **Skills renamed:** none
+- **Structural changes:** none
+
+### Removed
+- None
+
+### Migration
+- Existing v1.4.0 users: see `docs/MIGRATION.md`. All changes additive; no breaking changes. Re-running `/power-engineer configure` is NOT required — the hook scripts are shipped in-place via `npx skills add`. Operators are advised to periodically check `.power-engineer/memory-errors.log` for silent hook failures (now surfaced at hook start via stderr).
+
 ## [1.4.0] — 2026-04-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     Scan. Interview. Install. Configure. Done.
   </p>
   <p align="center">
-    <a href="https://github.com/kalshamsi/power-engineer-skills/releases/tag/v1.4.0"><img src="https://img.shields.io/badge/version-1.4.0-blue" alt="Version 1.4.0"></a>
+    <a href="https://github.com/kalshamsi/power-engineer-skills/releases/tag/v1.4.1"><img src="https://img.shields.io/badge/version-1.4.1-blue" alt="Version 1.4.1"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT License"></a>
     <img src="https://img.shields.io/badge/skills-231-orange" alt="231 Skills">
     <img src="https://github.com/kalshamsi/power-engineer-skills/actions/workflows/ci.yml/badge.svg" alt="CI">
@@ -221,39 +221,16 @@ Curated skill collections that install via specialized methods. Power Engineer p
 
 ---
 
-## What's New in v1.4.0
+## What's New in v1.4.1
 
-### Catalog versioning
+v1.4.1 is a strict-patch release addressing the two ⚠️ MINOR findings from the v1.4.0 security review:
 
-Every catalog change now bumps `power-engineer/.catalog-version` (semver). CI enforces that any PR touching `power-engineer/references/catalog/**` includes a version bump. See [catalog version conventions](docs/CONTRIBUTING.md#bumping-the-catalog-version) for bump rules (patch / minor / major).
+- **Filename collision prevention.** SessionEnd + PreCompact hook output filenames now include the current shell PID (`$$`) alongside the UTC timestamp, preventing clobber on sub-second concurrent invocations.
+- **Silent-failure observability.** Both hooks emit a one-line stderr warning at start when `.power-engineer/memory-errors.log` has accumulated prior failures. The warning is non-blocking (exit-0 hook contract preserved) and surfaces silent-failure accumulation that was otherwise invisible.
 
-Every release entry in `CHANGELOG.md` now includes a `### Catalog` subhead documenting the catalog version, skills added/removed/renamed, and structural changes. See [CHANGELOG `### Catalog` convention](docs/CONTRIBUTING.md#changelog--catalog-subhead) for the required schema.
+No catalog changes. No new skills. No architectural changes. All additive. See [`CHANGELOG.md`](CHANGELOG.md) and [`docs/MIGRATION.md`](docs/MIGRATION.md) for full detail.
 
-### Memory architecture (3-tier hooks)
-
-v1.4.0 adds a three-tier memory system so critical context survives across session boundaries and compaction events:
-
-| Hook / Command | When it fires | What it saves |
-|----------------|---------------|---------------|
-| **SessionEnd hook** | Claude Code session ends | Accomplishments, decisions, open tasks, next steps |
-| **PreCompact hook** | Context approaches compaction threshold | Working state snapshot before context is trimmed |
-| `/power-engineer save-phase` | Manual mid-session checkpoint | Current phase progress, files modified, decisions made |
-
-Fallback contracts ensure graceful degradation when hooks are unavailable.
-
-### Subagent selector
-
-A new `subagent-selector` module gives Power Engineer fine-grained control over which model tier is used for each task. Five modes:
-
-| Mode | Behavior |
-|------|----------|
-| `selector` (default) | Auto-selects model tier based on task complexity |
-| `force-opus` | Always use Opus for all subagent dispatches |
-| `force-sonnet` | Always use Sonnet for all subagent dispatches |
-| `force-haiku` | Always use Haiku for all subagent dispatches |
-| `none` | Disable model-tier selection; use Claude Code defaults |
-
-Configure via `power engineer configure` → subagent model mode.
+For the v1.4.0 feature set (catalog versioning, 3-tier memory architecture, subagent selector), see the [v1.4.0 release notes](https://github.com/kalshamsi/power-engineer-skills/releases/tag/v1.4.0) or the v1.4.0 CHANGELOG entry.
 
 ---
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,5 +1,36 @@
 # Migration Guide
 
+## v1.4.0 → v1.4.1
+
+**TL;DR:** Two defensive-hardening fixes to the v1.4.0 SessionEnd + PreCompact hook scripts. All changes additive. Your existing skills + state continue to work.
+
+### What changed
+1. **Hook output filenames include process ID.** Both `session-end-handoff.sh` and `pre-compact-snapshot.sh` now append `$$` (current shell PID) to the timestamped output filename. Prevents sub-second collision when hooks fire in rapid succession.
+2. **Operator observability for silent hook failures.** Both hooks now emit a one-line stderr warning at start when `.power-engineer/memory-errors.log` contains prior entries. The warning is non-blocking (hook still exits 0) and surfaces the accumulated-failure case that would otherwise stay silent.
+
+### What users must do
+Nothing required. Upgrade is `npx skills add power-engineer@1.4.1` (or the pinned-SHA equivalent). Existing `.power-engineer/` state is preserved.
+
+### Optional
+Periodically check `.power-engineer/memory-errors.log` to surface silent hook failures:
+
+```bash
+cat .power-engineer/memory-errors.log
+```
+
+An empty file means no failures have been recorded. A non-empty file means at least one prior hook invocation encountered a failure (mkdir, write, etc.); the v1.4.1 stderr warning at hook start surfaces this automatically, but occasional manual inspection is a useful belt-and-suspenders habit for production projects.
+
+### Rollback
+To roll back to v1.4.0:
+
+```bash
+git revert <v1.4.1-release-commit>
+# or selectively
+git checkout v1.4.0 -- power-engineer/scripts/hooks/
+```
+
+No state cleanup required — v1.4.1 hook output files interleave cleanly with v1.4.0 output files (filename prefix unchanged; only the suffix adds `-$$`).
+
 ## v1.3.0 → v1.4.0
 
 **TL;DR:** All additive. Your existing skills + state continue to work. Re-run `/power-engineer configure` to enable new hooks and set your subagent-model preference.

--- a/docs/superpowers/plans/power-engineer-v1.4.1-upgrade-plan.md
+++ b/docs/superpowers/plans/power-engineer-v1.4.1-upgrade-plan.md
@@ -1,0 +1,777 @@
+# Power Engineer v1.4.1 Upgrade Plan — Hook-script hardening (security-review follow-ups)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. This is a strict-patch release — scope is the two ⚠️ MINOR findings from the v1.4.0 security review, nothing else. No new catalog rows, no new modules, no new templates. The 4-phase shape below is deliberately lighter than the v1.4.0 9-phase plan because the diff is ~6 lines of bash and two Markdown entries.
+
+**Goal:** Ship v1.4.1 as a strict-patch release addressing the two ⚠️ MINOR items from `docs/superpowers/plans/v1.4.0-security-review.md`: (1) sub-second timestamp collision in hook output filenames (append `$$` PID for uniqueness) and (2) operator observability for silent hook failures (optional stderr warning at hook start when `memory-errors.log` is non-empty, plus a CHANGELOG/MIGRATION note directing operators to check the log). No new features; no Cluster C work. Second dogfood pass of the Phase 6 `changelog-entry-template.md` + `migration-template.md` introduced in v1.4.0.
+
+**Architecture:** Four phases rather than nine because the release is surgical. Phase 0 confirms the `$$`-append idiom on macOS bash 3.2 + zsh via a research subagent (External API gate). Phase 1 applies the two fixes under a Dev + Opus Auditor pair (hook-surface = HIGH-CAUTION). Phase 2 instantiates CHANGELOG v1.4.1 + MIGRATION v1.4.0 → v1.4.1 entries directly from the templates (dogfood); any template defect discovered fixes in-place per `release-process.md` §9. Phase 3 is the release ceremony, including a focused Opus security re-review of the patched scripts, Dual-Opus Template E end-to-end audit, tag, and GitHub release.
+
+**Tech Stack:** Bash (hook scripts) + Markdown (CHANGELOG, MIGRATION) + YAML (GitHub Actions CI — touched only if `tests/run-all.sh` surfaces regressions). No new tools. ShellCheck remains the ship-time lint gate; `bash tests/run-all.sh` is the ship-time aggregator.
+
+**Related artifacts:**
+- Security review (v1.4.1 scope source): `docs/superpowers/plans/v1.4.0-security-review.md`
+- Prior release plan (structure reference): `docs/superpowers/plans/power-engineer-v1.4.0-upgrade-plan.md`
+- Prior retrospective: `~/.claude/projects/-Users-khalfan-Documents-Development-power-engineer-skills/memory/project_v140_released.md`
+- Cross-cutting policy: `docs/superpowers/release-process/release-process.md`
+- Feedback memories consumed during authoring: `feedback_plan_pattern_verification.md`, `feedback_external_api_verification.md`
+- Templates dogfooded this release: `docs/superpowers/release-process/templates/changelog-entry-template.md`, `docs/superpowers/release-process/templates/migration-template.md`
+
+---
+
+## File Structure
+
+Files created or modified, grouped by responsibility:
+
+**Hook content (INSIDE `power-engineer/` — ships with the skill):**
+- Modify: `power-engineer/scripts/hooks/session-end-handoff.sh` — append `$$` to `handoff_file` filename; optional stderr warning when `memory-errors.log` is non-empty at hook start
+- Modify: `power-engineer/scripts/hooks/pre-compact-snapshot.sh` — append `$$` to `snapshot_file` filename; optional stderr warning when `memory-errors.log` is non-empty at hook start
+
+**Catalog hygiene (INSIDE `power-engineer/`):**
+- `.catalog-version` is NOT bumped (no catalog rows added/removed/renamed; no structural changes). CI `catalog-version-sync` enforces that it stays at `1.4.0`. CHANGELOG `### Catalog` subhead records `unchanged`.
+
+**Docs + release ceremony (OUTSIDE `power-engineer/`):**
+- Modify: `CHANGELOG.md` — v1.4.1 entry (instantiated from `changelog-entry-template.md`)
+- Modify: `docs/MIGRATION.md` — v1.4.0 → v1.4.1 entry (instantiated from `migration-template.md`)
+- Modify: `README.md` — version badge `1.4.0` → `1.4.1`; `## What's New in v1.4.0` → `## What's New in v1.4.1` with a short summary
+- **NOT modified**: `power-engineer/SKILL.md` — verified via `grep` (2026-04-17): contains zero literal version references. Per `writing-skills` discipline, SKILL.md is a pure trigger-description file (name + description frontmatter only). Version bumps do not belong there. Leaving untouched preserves CSO trigger integrity.
+
+**Release-process artifacts (OUTSIDE `power-engineer/` — maintainer-only, force-committed):**
+- Create: `docs/superpowers/plans/power-engineer-v1.4.1-upgrade-plan.md` (this file)
+- Create: `docs/superpowers/plans/v1.4.1-shellcheck-research.md` (Phase 0 Task 0.2 output)
+- Create: `docs/superpowers/plans/v1.4.1-security-review.md` (Phase 3 Task 3.1 output)
+- Modify (in-place per `release-process.md` §9 if dogfood surfaces defects): `docs/superpowers/release-process/templates/plan-template.md` awk-range command on line 240 (known-defective; see Plan-Pattern Verification Gates row 1)
+
+---
+
+## Phase 0 — Audit & Prep
+
+**Goal:** Create the `v1.4.1-upgrade` branch, verify a clean baseline, and commission one research subagent to confirm the `$$`/`$RANDOM` idiom behaves correctly on every shell the hooks may run under (bash 3.2 macOS default / bash 5.x Homebrew / zsh 5.x macOS default — Claude Code hooks invoke scripts via their shebang, which is `#!/usr/bin/env bash`, so bash dominates but zsh compatibility matters if users source the scripts manually).
+
+### Task 0.1: Create working branch
+
+**Files:** None (git operation)
+
+- [ ] **Step 1: Create branch tracking origin**
+
+```bash
+git checkout main
+git pull
+git checkout -b v1.4.1-upgrade
+git push -u origin v1.4.1-upgrade
+```
+
+Expected: `v1.4.1-upgrade` tracks `origin/v1.4.1-upgrade`. This push is the single mid-release exception to the push-at-release-time policy (per `release-process.md` §4).
+
+- [ ] **Step 2: Confirm clean starting state**
+
+```bash
+git status
+bash tests/run-all.sh
+```
+
+Expected: clean tree; lint suite exits 0 (same state as post-v1.4.0 release `d91f905`).
+
+### Task 0.2: Research subagent — `$$`/`$RANDOM` idiom verification
+
+**Files:** Create: `docs/superpowers/plans/v1.4.1-shellcheck-research.md` (force-committed)
+
+Per `feedback_external_api_verification.md` + `release-process.md` §8, any change touching hook scripts is external-surface work. Even though `$$` is a POSIX shell special variable, we dispatch a focused Sonnet research subagent to confirm:
+
+- [ ] **Step 1: Dispatch Research subagent (Sonnet)**
+
+Brief (full wording lives in the executor prompt; here is the skeleton):
+
+> You are a research subagent for Power Engineer v1.4.1. Confirm the following technical claims by consulting authoritative sources (bash manual, POSIX spec, macOS zsh manual) — do NOT rely on training-data memory:
+> 1. In bash 3.2 (macOS system default) and bash 5.x, does `$$` expand to the current shell's PID inside a script invoked via `#!/usr/bin/env bash`?
+> 2. Does `$$` behave the same way in zsh 5.x (macOS default login shell) if the script is sourced rather than executed?
+> 3. Is there any ShellCheck warning (SC1000-series) triggered by `"${handoff_file}-$$"` or `"${handoff_file}-$RANDOM"` in strict mode? Run `shellcheck --severity=style` on a minimal example.
+> 4. Confirm the PID-append idiom produces unique filenames under rapid successive invocation (test: run a loop of 10 script invocations in the same UTC second, observe filenames).
+> 5. Compare `$$` vs `$RANDOM` for this use case. Does either carry a known bash quirk (e.g., `$RANDOM` reuse when multiple subshells are spawned in the same second)?
+>
+> Save findings as structured markdown to `docs/superpowers/plans/v1.4.1-shellcheck-research.md`. Include: one-paragraph summary, per-question answers with citations, concrete recommendation (use `$$`, use `$RANDOM`, or use both concatenated — e.g. `-$$-$RANDOM`). If the recommendation contradicts the plan text, flag it so the orchestrator can update the plan before dispatching Phase 1 Dev.
+
+- [ ] **Step 2: Review subagent output**
+
+Confirm the report covers all 5 questions and produces an explicit recommendation. If the recommendation diverges from the plan's default (`$$`), surface via `AskUserQuestion` before proceeding.
+
+- [ ] **Step 3: Commit the research doc**
+
+```bash
+git add -f docs/superpowers/plans/v1.4.1-shellcheck-research.md
+git commit -m "docs(v1.4.1): shellcheck + \$\$/\$RANDOM idiom research (Phase 0)"
+```
+
+### Task 0.3: Phase 0 checkpoint
+
+**Files:** None (git operation)
+
+- [ ] **Step 1: Empty checkpoint commit**
+
+```bash
+git commit --allow-empty -m "checkpoint: Phase 0 complete and approved by user"
+```
+
+### Phase 0 Verification
+
+- [ ] Branch `v1.4.1-upgrade` exists and tracks origin
+- [ ] `docs/superpowers/plans/v1.4.1-shellcheck-research.md` exists and contains an explicit idiom recommendation
+- [ ] `bash tests/run-all.sh` → exit 0 (clean baseline, lint unaffected)
+- [ ] Empty checkpoint commit present on branch
+
+---
+
+## Phase 1 — Patch Hook Scripts
+
+**Goal:** Apply the two security-review minor fixes to both hook scripts.
+
+### Task 1.1: Patch `session-end-handoff.sh`
+
+**Files:** Modify: `power-engineer/scripts/hooks/session-end-handoff.sh`
+
+**Risk class:** HIGH-CAUTION (hook surface, external API). Model assignment: Sonnet Dev acceptable since the diff is mechanical (2 edits, ~6 lines total); Auditor MUST be Opus per `subagent-selector.md` audit row.
+
+- [ ] **Step 1: Append `$$` to handoff_file**
+
+Change line 82 from:
+
+```bash
+handoff_file="${state_dir}/session-handoff-${timestamp_filename}.md"
+```
+
+to (exact string per Phase 0 research recommendation; default is `-$$`):
+
+```bash
+handoff_file="${state_dir}/session-handoff-${timestamp_filename}-$$.md"
+```
+
+- [ ] **Step 2: Add memory-errors.log surfacing at hook start**
+
+Insert BEFORE line 21 (before `project_dir=` resolution) a block that emits a stderr warning if the memory-errors log already has content. Exact wording subject to Phase 0 research confirmation; target shape:
+
+```bash
+# ── Operator observability: surface prior hook failures ──────────────────────
+# If memory-errors.log already has entries from prior invocations, emit a
+# one-line stderr note so operators notice silent-failure accumulation. This
+# does NOT block the hook (exit 0 on every path is still the contract).
+_prior_errlog="${CLAUDE_PROJECT_DIR:-$PWD}/.power-engineer/memory-errors.log"
+if [[ -s "$_prior_errlog" ]]; then
+    printf 'session-end-handoff.sh: prior hook errors logged at %s\n' "$_prior_errlog" >&2
+fi
+unset _prior_errlog
+```
+
+The guard:
+- `[[ -s file ]]` is a bash built-in (safe under `set -u` because we default via `${VAR:-}`).
+- Writes to stderr (FD 2), not stdout — Claude Code transcript surfaces stderr.
+- `unset` avoids polluting the later `log_error` scope.
+- Never fails the hook: if the read fails (unreadable file), the guard short-circuits; the rest of the script continues.
+
+- [ ] **Step 3: ShellCheck clean**
+
+```bash
+shellcheck power-engineer/scripts/hooks/session-end-handoff.sh
+```
+
+Expected: exit 0, no new SC warnings beyond the 2 existing SC2016 suppressions.
+
+- [ ] **Step 4: Manual smoke test**
+
+```bash
+# Run the hook twice in rapid succession, confirm two distinct output files
+TMP=$(mktemp -d)
+cp power-engineer/scripts/hooks/session-end-handoff.sh "$TMP/"
+CLAUDE_PROJECT_DIR="$TMP" bash "$TMP/session-end-handoff.sh" &
+CLAUDE_PROJECT_DIR="$TMP" bash "$TMP/session-end-handoff.sh" &
+wait
+ls -1 "$TMP/.power-engineer/session-handoff-"*.md | wc -l
+# Expected: 2
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add power-engineer/scripts/hooks/session-end-handoff.sh
+git commit -m "fix(hooks): prevent session-end-handoff filename collision + surface prior errors"
+```
+
+### Task 1.2: Patch `pre-compact-snapshot.sh`
+
+**Files:** Modify: `power-engineer/scripts/hooks/pre-compact-snapshot.sh`
+
+Same shape as Task 1.1, applied to `snapshot_file` on line 98 and an identical stderr-warning block before line 35 (before `project_dir=` resolution).
+
+- [ ] **Step 1: Append `$$` to snapshot_file**
+- [ ] **Step 2: Add memory-errors.log surfacing at hook start** (identical block, with `printf` prefix updated to `pre-compact-snapshot.sh:`)
+- [ ] **Step 3: ShellCheck clean** (expected: no new warnings beyond the 4 existing SC2016 suppressions)
+- [ ] **Step 4: Manual smoke test** (same as Task 1.1 Step 4, with `pre-compact-` filename prefix)
+- [ ] **Step 5: Commit**
+
+```bash
+git add power-engineer/scripts/hooks/pre-compact-snapshot.sh
+git commit -m "fix(hooks): prevent pre-compact-snapshot filename collision + surface prior errors"
+```
+
+### Task 1.3: Opus Auditor pass
+
+**Files:** None (audit only; no commit unless remediation required)
+
+- [ ] **Step 1: Dispatch Opus Auditor (Template B)**
+
+Brief the auditor with: the two security-review minor items (copy from `v1.4.0-security-review.md` §Recommendations), the two patched scripts, Phase 0 research doc, and the manual-smoke-test evidence. Auditor MUST re-run `shellcheck` and the smoke test; MUST verify the exit-0 hook contract is preserved on every path; MUST verify no new SC warnings beyond existing suppressions; MUST confirm PID-append idiom produces unique filenames under concurrent invocation.
+
+- [ ] **Step 2: On APPROVED, proceed to Task 1.4. On ISSUES FOUND, dispatch Remediator (Template C).** Re-audit after remediation; max two auto-remediations per `release-process.md` §3.
+
+### Task 1.4: Phase 1 checkpoint
+
+- [ ] **Step 1: Empty checkpoint commit**
+
+```bash
+git commit --allow-empty -m "checkpoint: Phase 1 complete and approved by user"
+```
+
+### Phase 1 Verification
+
+- [ ] Both hook scripts contain `${timestamp_filename}-$$` in the output filename variable
+- [ ] Both hook scripts emit a stderr warning at hook start when `memory-errors.log` is non-empty
+- [ ] `shellcheck power-engineer/scripts/hooks/*.sh` → exit 0
+- [ ] Concurrent-invocation smoke test produces N distinct files for N invocations
+- [ ] Opus Auditor returned APPROVED
+- [ ] `bash tests/run-all.sh` → exit 0
+
+---
+
+## Phase 2 — CHANGELOG + MIGRATION (Dogfood Templates)
+
+**Goal:** Instantiate `changelog-entry-template.md` and `migration-template.md` for v1.4.1. Second dogfood pass after v1.4.0 — surface + fix any template defects in-place per `release-process.md` §9. **Known defect entering this phase** (discovered during plan-pattern verification): `docs/superpowers/release-process/templates/plan-template.md` line 240 awk-range command closes the range on the start line when start + end regex both match the same `## [` header — will be fixed as part of Task 2.3 below.
+
+### Task 2.1: Write CHANGELOG v1.4.1 entry (instantiate template)
+
+**Files:** Modify: `CHANGELOG.md`
+
+**Model:** Sonnet Dev (content-only prose work).
+
+- [ ] **Step 1: Insert v1.4.1 entry ABOVE the v1.4.0 entry**
+
+Entry shape (derived from `changelog-entry-template.md`):
+
+```markdown
+## [1.4.1] — <YYYY-MM-DD>
+
+### Added
+- Stderr warning at hook start when `.power-engineer/memory-errors.log` contains prior entries — operator-observability surface for silent hook failures (addresses v1.4.0 security review ⚠️ MINOR #2)
+
+### Changed
+- `power-engineer/scripts/hooks/session-end-handoff.sh` and `power-engineer/scripts/hooks/pre-compact-snapshot.sh` output filenames now include process ID (`$$`) alongside the UTC second-resolution timestamp — prevents filename collision on sub-second concurrent invocations (addresses v1.4.0 security review ⚠️ MINOR #1)
+
+### Catalog
+- **Catalog version:** 1.4.0 (unchanged)
+- **Skills added:** none
+- **Skills removed:** none
+- **Skills renamed:** none
+- **Structural changes:** none
+
+### Removed
+- None
+
+### Migration
+- Existing v1.4.0 users: see `docs/MIGRATION.md`. All changes additive; no breaking changes. Re-run `/power-engineer configure` is NOT required — the hook scripts are shipped in-place via `npx skills add`. Operators are advised to periodically check `.power-engineer/memory-errors.log` for silent hook failures (now surfaced at hook start via stderr).
+```
+
+Replace `<YYYY-MM-DD>` with the actual tag date at commit time.
+
+- [ ] **Step 2: Verify v1.4.1 CHANGELOG entry is template-derived (dogfood check)**
+
+Use the CORRECTED awk-range pattern (flag-based; see Plan-Pattern Verification Gates row 1):
+
+```bash
+diff \
+  <(grep -E '^### ' docs/superpowers/release-process/templates/changelog-entry-template.md) \
+  <(awk '/^## \[1.4.1\]/{flag=1; next} flag && /^## \[/{exit} flag' CHANGELOG.md | grep -E '^### ') \
+  && echo "OK: v1.4.1 CHANGELOG structurally derived from template" \
+  || echo "FAIL: changelog entry diverges from template shape (dogfooding gap)"
+```
+
+Expected: matching `###` subheads in the same order (Added / Changed / Catalog / Removed / Migration). Divergence → fix the template OR the entry in-place per `release-process.md` §9.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: add CHANGELOG v1.4.1 entry"
+```
+
+### Task 2.2: Write MIGRATION v1.4.0 → v1.4.1 entry (instantiate template)
+
+**Files:** Modify: `docs/MIGRATION.md`
+
+**Model:** Sonnet Dev (content-only prose work).
+
+- [ ] **Step 1: Insert v1.4.0 → v1.4.1 entry ABOVE the v1.3.0 → v1.4.0 entry**
+
+Entry shape (derived from `migration-template.md`):
+
+```markdown
+## v1.4.0 → v1.4.1
+
+**TL;DR:** Two defensive-hardening fixes to the v1.4.0 SessionEnd + PreCompact hook scripts. All changes additive. Your existing skills + state continue to work.
+
+### What changed
+1. **Hook output filenames include process ID.** Both `session-end-handoff.sh` and `pre-compact-snapshot.sh` now append `$$` (current shell PID) to the timestamped output filename. Prevents sub-second collision when hooks fire in rapid succession.
+2. **Operator observability for silent hook failures.** Both hooks now emit a one-line stderr warning at start when `.power-engineer/memory-errors.log` contains prior entries. The warning is non-blocking (hook still exits 0) and surfaces the accumulated-failure case that would otherwise stay silent.
+
+### What users must do
+Nothing required. Upgrade is `npx skills add power-engineer@1.4.1` (or the pinned-SHA equivalent). Existing `.power-engineer/` state is preserved.
+
+### Optional
+Periodically check `.power-engineer/memory-errors.log` to surface silent hook failures:
+
+```bash
+cat .power-engineer/memory-errors.log
+```
+
+Empty file = no failures recorded. Non-empty file = hooks have logged at least one failure; the stderr warning at v1.4.1 hook start will now surface this, but operators checking manually is a useful belt-and-suspenders habit.
+
+### Rollback
+To roll back to v1.4.0:
+
+```bash
+git revert <v1.4.1-release-commit>
+# or
+git checkout v1.4.0 -- power-engineer/scripts/hooks/
+```
+
+No state cleanup required — the v1.4.1 hook output files interleave cleanly with v1.4.0 output files (filename prefix unchanged; only the suffix adds `-$$`).
+```
+
+- [ ] **Step 2: Verify v1.4.0 → v1.4.1 MIGRATION entry is template-derived (dogfood check)**
+
+Use the corrected flag-based awk-range pattern (see Plan-Pattern Verification Gates row 2):
+
+```bash
+diff \
+  <(grep -E '^### ' docs/superpowers/release-process/templates/migration-template.md) \
+  <(awk '/^## v1.4.0 → v1.4.1/{flag=1; next} flag && /^## v/{exit} flag' docs/MIGRATION.md | grep -E '^### ') \
+  && echo "OK: v1.4.0 → v1.4.1 MIGRATION structurally derived from template" \
+  || echo "FAIL: migration entry diverges from template shape (dogfooding gap)"
+```
+
+Expected: matching `###` subheads in the same order (What changed / What users must do / Optional / Rollback).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/MIGRATION.md
+git commit -m "docs: add MIGRATION v1.4.0 → v1.4.1 entry"
+```
+
+### Task 2.3: Fix plan-template.md awk-range defect (template in-place fix)
+
+**Files:** Modify: `docs/superpowers/release-process/templates/plan-template.md`
+
+Per `release-process.md` §9 "in-place fix protocol": the dogfood commands above use the corrected flag-based awk pattern. The plan-template at line 240 ships a defective pattern (`/^## \[<X.Y.Z>\]/,/^## \[/`) that closes the range on the start line. Fix both the template text AND leave a one-line comment explaining the trap so the next planner doesn't re-introduce it.
+
+- [ ] **Step 1: Update plan-template.md line 240 region**
+
+Replace the defective command block (around lines 237-243) with:
+
+```bash
+# Use a flag-based awk pattern rather than the `/^## \[X.Y.Z\]/,/^## \[/` range
+# form — the range form closes on the start line when the start+end regex both
+# match the same `## [` header, truncating extracted subheads to zero.
+diff \
+  <(grep -E '^### ' docs/superpowers/release-process/templates/changelog-entry-template.md) \
+  <(awk '/^## \[<X.Y.Z>\]/{flag=1; next} flag && /^## \[/{exit} flag' CHANGELOG.md | grep -E '^### ') \
+  && echo "OK: v<X.Y.Z> CHANGELOG structurally derived from template" \
+  || echo "FAIL: changelog entry diverges from template shape (dogfooding gap)"
+```
+
+- [ ] **Step 2: Verify no other awk-range occurrences in templates**
+
+```bash
+/usr/bin/grep -rn "awk '/.*\[.*\].*/,/.*\[.*\]/'" docs/superpowers/release-process/templates/ || echo "OK: no other defective awk ranges"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/release-process/templates/plan-template.md
+git commit -m "fix(release-process): correct plan-template awk-range dogfood command"
+```
+
+### Task 2.4: Sonnet Auditor pass on Phase 2
+
+**Files:** None (audit only)
+
+- [ ] **Step 1: Dispatch Sonnet Auditor (Template B)**
+
+Audit brief: verify CHANGELOG v1.4.1 entry + MIGRATION v1.4.0→v1.4.1 entry both pass the corrected dogfood diffs; verify the template defect fix landed cleanly; verify `bash tests/run-all.sh` stays green (CI `catalog-version-sync` MUST NOT fire — `.catalog-version` is unchanged at `1.4.0`); verify no other `awk` range defects in any template.
+
+- [ ] **Step 2: On APPROVED, proceed to Task 2.5. On ISSUES FOUND, dispatch Remediator.**
+
+### Task 2.5: Phase 2 checkpoint
+
+- [ ] **Step 1: Empty checkpoint commit**
+
+```bash
+git commit --allow-empty -m "checkpoint: Phase 2 complete and approved by user"
+```
+
+### Phase 2 Verification
+
+- [ ] CHANGELOG.md v1.4.1 entry present; 5 `### ` subheads match template (dogfood diff passes)
+- [ ] docs/MIGRATION.md v1.4.0→v1.4.1 entry present; 4 `### ` subheads match template (dogfood diff passes)
+- [ ] `power-engineer/.catalog-version` unchanged at `1.4.0`
+- [ ] plan-template.md line 240 awk-range defect fixed
+- [ ] Sonnet Auditor returned APPROVED
+- [ ] `bash tests/run-all.sh` → exit 0
+
+---
+
+## Phase 3 — Release Ceremony
+
+**Goal:** Ship v1.4.1. Version bumps, Opus security re-review of patched scripts, Dual-Opus Template E end-to-end audit, user checkpoint, draft PR → ready → squash-merge → annotated tag → GitHub release → post-release dogfood of `/power-engineer save-phase`.
+
+**Risk class:** HIGH-CAUTION throughout. Model assignment: Opus for every auditor + Dev in this phase per `release-process.md` §3 + `subagent-selector.md` audit+release-ceremony rows.
+
+### Task 3.1: Version bumps
+
+**Files:** Modify: `README.md` only (SKILL.md verified zero-references at plan-authoring time; leave untouched per `writing-skills` trigger-integrity guidance).
+
+**Model:** Sonnet Dev (mechanical string replacement).
+
+- [ ] **Step 1: Grep for forward-looking version references**
+
+```bash
+/usr/bin/grep -rn 'v1\.4\.0\|1\.4\.0' README.md 2>/dev/null
+```
+
+Expected hits (verified 2026-04-17):
+- `README.md:8` — version badge `version-1.4.0-blue`
+- `README.md:224` — `## What's New in v1.4.0`
+- `README.md:234` — `v1.4.0 adds a three-tier memory system...`
+
+Review each hit individually. Historical entries in CHANGELOG and MIGRATION MUST NOT be bumped.
+
+- [ ] **Step 2: Update each forward-looking occurrence to v1.4.1**
+
+For README `What's New` section, replace the v1.4.0 prose with a short v1.4.1 summary:
+
+```markdown
+## What's New in v1.4.1
+
+v1.4.1 is a strict-patch release addressing two ⚠️ MINOR findings from the v1.4.0 security review:
+
+- **Filename collision prevention.** SessionEnd + PreCompact hook output filenames now include the current shell PID (`$$`) alongside the UTC timestamp, preventing clobber on sub-second concurrent invocations.
+- **Silent-failure observability.** Both hooks emit a one-line stderr warning at start when `.power-engineer/memory-errors.log` has accumulated prior failures. The warning is non-blocking and surfaces the silent-failure accumulation case.
+
+No catalog or architectural changes. All additive. See `CHANGELOG.md` + `docs/MIGRATION.md` for full detail.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: bump version references 1.4.0 → 1.4.1"
+```
+
+### Task 3.2: Opus security re-review of patched scripts
+
+**Files:** Create: `docs/superpowers/plans/v1.4.1-security-review.md` (force-committed)
+
+**Model:** Opus security-review subagent (separate dispatch, fresh context).
+
+- [ ] **Step 1: Dispatch Opus security-review subagent**
+
+Brief: Review the two patched hook scripts against the same threat model as `v1.4.0-security-review.md` (shell injection / path traversal / env var assumptions / race conditions / error handling / Power Engineer-specific). Explicitly verify:
+1. The `-$$` filename suffix does not introduce a new injection surface (PID is bash-integer; interpolated as `%s` data → safe).
+2. The new stderr-warning block at hook start does not break the exit-0 hook contract on any path (e.g., `[[ -s file ]]` on an unreadable file — does it return non-zero and trigger the ERR trap?).
+3. Both scripts still ShellCheck-clean with the documented 6 SC2016 suppressions.
+4. Both scripts still defend against hostile `CLAUDE_PROJECT_DIR`, commit messages with `$(…)`, branch-name newline injection.
+
+Save report to `docs/superpowers/plans/v1.4.1-security-review.md`. Recommended format: same structure as `v1.4.0-security-review.md` (Summary + per-script Findings + Verdict).
+
+- [ ] **Step 2: Address findings**
+
+Critical findings: block release; dispatch Remediator. Minor findings: note for v1.4.2 or fix in-place per user AskUserQuestion.
+
+- [ ] **Step 3: Commit the security-review doc**
+
+```bash
+git add -f docs/superpowers/plans/v1.4.1-security-review.md
+git commit -m "docs(v1.4.1): Opus security re-review of patched hook scripts"
+```
+
+### Task 3.3: User checkpoint before PR
+
+**Files:** None
+
+- [ ] **Step 1: AskUserQuestion — proceed to PR?**
+
+Surface to the user via `AskUserQuestion`: "Phase 0-3 Task 3.2 complete. Security re-review is RELEASE-SAFE. Ready to push + create draft PR?" Options: proceed / review specific commits first / abort.
+
+- [ ] **Step 2: Empty checkpoint commit**
+
+```bash
+git commit --allow-empty -m "checkpoint: Phase 3 pre-PR audits complete and approved by user"
+```
+
+### Task 3.4: Push branch + create draft PR
+
+**Files:** None (git + gh operations)
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push
+```
+
+This is the first push of v1.4.1 content (Phase 0 Task 0.1 pushed the empty branch). Per `release-process.md` §4, mid-release pushes are forbidden; this push occurs inside the release ceremony.
+
+- [ ] **Step 2: Create draft PR**
+
+```bash
+gh pr create --draft \
+  --title "v1.4.1 — Hook-script hardening (security-review follow-ups)" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Strict-patch release addressing the two ⚠️ MINOR items from the v1.4.0 security review:
+
+1. Hook output filenames now include `$$` (PID) to prevent sub-second collision.
+2. Both hooks emit a one-line stderr warning at start when `memory-errors.log` has prior entries.
+
+No catalog changes. No new features. Second dogfood pass of the v1.4.0 release-process templates.
+
+## Test plan
+
+- [x] `shellcheck power-engineer/scripts/hooks/*.sh` clean
+- [x] Concurrent-invocation smoke test produces N distinct output files for N invocations
+- [x] `bash tests/run-all.sh` exit 0
+- [x] Dogfood diffs (CHANGELOG + MIGRATION) pass against templates
+- [x] Opus security re-review: RELEASE-SAFE
+- [ ] CI green on draft PR
+
+See `CHANGELOG.md` v1.4.1 entry for full changelog; `docs/MIGRATION.md` v1.4.0 → v1.4.1 for upgrade path.
+EOF
+)"
+gh pr checks --watch
+```
+
+Expected: all CI jobs pass green, including `catalog-version-sync` (verifies `.catalog-version` is `1.4.0` and no catalog rows changed).
+
+### Task 3.5: Final Dual-Opus end-to-end audit
+
+**Files:** None (audit only)
+
+**Model:** 2 × Opus auditor (Template E dual-review pattern) per `release-process.md` §3.
+
+- [ ] **Step 1: Dispatch two Opus Template E auditors in parallel**
+
+Both briefed on: full plan, all commits on `v1.4.1-upgrade` branch, security-review doc, CHANGELOG + MIGRATION entries, template fix. Each auditor independently verifies release readiness (criteria list below).
+
+Criteria (each auditor returns PASS/FAIL per row):
+1. Both hook scripts include `$$` in output filename
+2. Both hook scripts emit stderr warning at start when memory-errors.log is non-empty
+3. Exit-0 hook contract preserved on every path
+4. ShellCheck clean on both scripts (existing suppressions only)
+5. CHANGELOG v1.4.1 entry structurally derived from changelog-entry-template.md
+6. MIGRATION v1.4.0→v1.4.1 entry structurally derived from migration-template.md
+7. plan-template.md awk-range defect fixed in-place
+8. `.catalog-version` unchanged at `1.4.0`
+9. README + SKILL.md version bumps applied (no stale `1.4.0` in forward-looking text)
+10. No push occurred mid-release (single branch-push at Phase 0 Task 0.1, single content-push at Phase 3 Task 3.4)
+11. Opus security re-review RELEASE-SAFE
+12. CI green on draft PR
+13. `bash tests/run-all.sh` exit 0 on current HEAD
+
+- [ ] **Step 2: Reconcile dual-auditor findings**
+
+Agreed PASS → proceed. Any FAIL → dispatch Remediator; re-audit after. Max one round of auto-remediation at this phase; on second FAIL, escalate via AskUserQuestion (options: remediate manually / abort release / defer to v1.4.2).
+
+### Task 3.6: Merge + tag + release
+
+**Files:** None (git + gh operations)
+
+- [ ] **Step 1: Mark PR ready + squash-merge**
+
+```bash
+gh pr ready
+gh pr merge --squash --admin
+```
+
+`--admin` bypass per `release-process.md` §5.
+
+- [ ] **Step 2: Merge-confirmation gate (MANDATORY — halts if merge silently failed)**
+
+```bash
+git checkout main
+git pull
+if ! git log --oneline -20 | /usr/bin/grep -qi 'v1.4.1'; then
+  echo "v1.4.1 squash commit not found on main — aborting tag"
+  exit 1
+fi
+```
+
+- [ ] **Step 3: Tag annotated**
+
+```bash
+git tag -a v1.4.1 -m "Power Engineer v1.4.1 — Hook-script hardening (security-review follow-ups)"
+git push origin v1.4.1
+```
+
+- [ ] **Step 4: Create GitHub release**
+
+```bash
+gh release create v1.4.1 \
+  --title "v1.4.1 — Hook-script hardening (security-review follow-ups)" \
+  --verify-tag \
+  --notes-file <(sed -n '/## \[1.4.1\]/,/## \[/p' CHANGELOG.md | sed '$d')
+```
+
+`--verify-tag` is the defensive guard baked in during v1.4.0 Phase 9 Task 9.5 gh-CLI research (see `project_v140_released.md`).
+
+- [ ] **Step 5: Verify release is live**
+
+```bash
+gh release view v1.4.1
+```
+
+Expected: release URL returns; `isDraft: false`; `isPrerelease: false`; body matches CHANGELOG extract.
+
+### Task 3.7: Post-release — save session memory
+
+**Files:** Create: `~/.claude/projects/-Users-khalfan-Documents-Development-power-engineer-skills/memory/project_v141_released.md` (via /power-engineer save-phase or direct Write)
+
+- [ ] **Step 1: Invoke `/power-engineer save-phase`** (dogfood the explicit-save flow — third-tier memory)
+- [ ] **Step 2: Verify memory file created**
+
+```bash
+ls -la ~/.claude/projects/-Users-khalfan-Documents-Development-power-engineer-skills/memory/project_v141_released.md
+```
+
+### Phase 3 Verification
+
+- [ ] README + SKILL.md version bumps applied (forward-looking only; historical untouched)
+- [ ] Opus security re-review: RELEASE-SAFE; report committed at `docs/superpowers/plans/v1.4.1-security-review.md`
+- [ ] Dual-Opus Template E end-to-end audit: both auditors return all criteria PASS
+- [ ] PR merged via `gh pr merge --squash --admin`
+- [ ] Merge-confirmation gate passed (v1.4.1 squash commit present on main)
+- [ ] Tag `v1.4.1` pushed; annotated (`git cat-file -t v1.4.1` = "tag")
+- [ ] GitHub release published (`gh release view v1.4.1` returns)
+- [ ] `/power-engineer save-phase` invoked post-release; retrospective memory file created
+
+---
+
+## Plan-Pattern Verification Gates
+
+Per `feedback_plan_pattern_verification.md`: patterns spot-checked against real files before plan ships to executors.
+
+| # | Pattern (paste verbatim) | Intended target file(s) | Expected match count | Actual match count | PASS / FAIL |
+|---|---|---|---|---|---|
+| 1 | `awk '/^## \[1.4.0\]/{flag=1; next} flag && /^## \[/{exit} flag' CHANGELOG.md \| grep -cE '^### '` (corrected flag-based range, dry-run against v1.4.0 as v1.4.1 stand-in) | `CHANGELOG.md` (v1.4.0 section, 5 subheads); `CHANGELOG.md` post-v1.4.1-entry (5 subheads) | 5 | 5 | PASS |
+| 2 | `awk '/^## v1.3.0 → v1.4.0/{flag=1; next} flag && /^## v/{exit} flag' docs/MIGRATION.md \| grep -cE '^### '` (dry-run against v1.3.0→v1.4.0 as v1.4.0→v1.4.1 stand-in) | `docs/MIGRATION.md` (v1.3.0→v1.4.0 section, 4 subheads) | 4 | 4 | PASS |
+| 3 | `grep -cE '^### ' docs/superpowers/release-process/templates/changelog-entry-template.md` | template file | 5 | 5 | PASS |
+| 4 | `grep -cE '^### ' docs/superpowers/release-process/templates/migration-template.md` | template file | 4 | 4 | PASS |
+| 5 | `/usr/bin/grep -rn 'v1\.4\.0\|1\.4\.0' README.md` (Phase 3.1 bump detection) | `README.md` | ≥3 (badge, "What's New" heading, body prose) | 3 (lines 8, 224, 234) | PASS |
+| 6 | `sed -n '/## \[1.4.1\]/,/## \[/p' CHANGELOG.md \| sed '$d'` (gh release notes extractor, works correctly on sed per §Phase 0 verification — sed range semantics tolerate start+end-on-same-line) | `CHANGELOG.md` (post-v1.4.1-entry) | non-empty; ≥20 lines | TBD post-Task 2.1 | UNVERIFIED (rely on sed semantics; dry-run against v1.4.0 returned 27 lines) |
+
+**Known defect surfaced at plan-authoring time:** `docs/superpowers/release-process/templates/plan-template.md` line 240 ships the awk-range form `/^## \[<X.Y.Z>\]/,/^## \[/` which closes the range on the start line. Fixed in-place as part of Task 2.3. The defect was latent in v1.4.0 (never exercised as a literal template instantiation).
+
+**Failure handling:** All rows above read PASS at plan-ship time. Row 6 is verified post-Task 2.1 before the Phase 3.4 release-creation command relies on it.
+
+---
+
+## External API Research Gates
+
+Per `feedback_external_api_verification.md`.
+
+**In-scope surfaces for this release:**
+- Claude Code hooks (SessionEnd, PreCompact scripts)
+- `gh` CLI flags (pr merge, release create, release view)
+- macOS bash 3.2 / bash 5.x / zsh compatibility for `$$` and `[[ -s file ]]`
+
+**Planner checklist:**
+
+| # | Task | External surface touched | Research subagent dispatched (Phase / Task) | Output saved to | Dev brief references the doc? |
+|---|---|---|---|---|---|
+| 1 | Task 1.1, 1.2 | Claude Code hook surface + bash `$$`/`[[ -s ]]` idioms | Phase 0 Task 0.2 | `docs/superpowers/plans/v1.4.1-shellcheck-research.md` | **yes — dispatch Dev only after research doc exists and is referenced in brief** |
+| 2 | Task 3.4, 3.6 | `gh pr create --draft`, `gh pr ready`, `gh pr merge --squash --admin`, `gh release create --verify-tag`, `gh release view` | **reuse** `docs/superpowers/plans/v1.4.0-gh-cli-research.md` (v1.4.0 findings still current; no gh CLI major-version bump in the last month) | v1.4.0 research doc | **yes — orchestrator confirms no gh version drift before Phase 3.4 via `gh --version` and a quick release-notes spot-check** |
+
+**Failure handling:** Row 1 MUST be "yes" before dispatching Phase 1 Devs. Row 2 allows reuse; if a `gh` major bump ships between v1.4.0 and v1.4.1 ship-date, dispatch a fresh research subagent.
+
+**Auditor brief reminder:** Phase 1.3 Auditor + Phase 3.5 Dual-Opus Auditor both cross-check that Devs consumed the research docs' recommendations (e.g., used `$$` if that was the research recommendation; did not revert to a remembered `$RANDOM` form without justification).
+
+---
+
+## Risk & Rollback
+
+### Biggest risks
+
+- **Phase 1 (hook patch)** — hook-surface change affects every user who ran `/power-engineer configure`; if the stderr-warning block breaks the exit-0 contract, SessionEnd or PreCompact could block session termination or compaction. Mitigation: Phase 0 research + Phase 1.3 Opus Auditor with explicit exit-code verification + Phase 3.2 Opus security re-review.
+- **Phase 2 (template dogfood)** — plan-template awk-range defect MUST be fixed in-place; Task 2.3 is the sole fix for it. If Task 2.3 is skipped, v1.4.2+ inherits the defect. Mitigation: Task 2.3 is a separate discrete task (not a sub-step), gated by the Phase 2 Sonnet Auditor.
+- **Phase 3 (release ceremony)** — first dogfood of the v1.4.0 templates that did NOT instantiate in v1.4.0's own release (plan-template itself was created in v1.4.0 Phase 6 but v1.4.0 used a plan authored in parallel, not via template instantiation). Any further latent template defects surface here. Mitigation: in-place fix protocol per `release-process.md` §9; user AskUserQuestion before each in-place template fix so scope creep stays visible.
+
+### Rollback per phase
+
+| Phase | Risk | Likelihood | Mitigation | Per-phase rollback command(s) |
+|---|---|---|---|---|
+| 0 | Branch contaminated | Low | Branch is empty pre-implementation | `git checkout main && git branch -D v1.4.1-upgrade` |
+| 1 | Hook patch breaks exit-0 contract | Low | Opus Auditor re-runs exit-code verification | `git revert <phase-1-task-1.1-commit> <phase-1-task-1.2-commit>` |
+| 2 | CHANGELOG/MIGRATION content wrong; template fix wrong | Low | Sonnet Auditor runs dogfood diffs | `git revert <phase-2-commits-2.1 2.2 2.3>` |
+| 3 | Tag pushed prematurely / merge-confirmation gate skipped | Low | Step 2 gate + `--verify-tag` on release create; never delete tags without user approval | `git tag -d v1.4.1; git push --delete origin v1.4.1; gh release delete v1.4.1 --yes; git revert <squash-commit>` |
+
+### Full-release rollback
+
+```bash
+git checkout main
+git revert <squash-commit-of-v1.4.1-PR>
+git tag -d v1.4.1
+git push origin :refs/tags/v1.4.1
+gh release delete v1.4.1 --yes
+```
+
+Restores v1.4.0 behavior. No user-side action required — the hook scripts are shipped in-place via `npx skills add`; users who upgrade to v1.4.1 and then downgrade have their state preserved (filename prefix unchanged; only the `-$$` suffix addition differs).
+
+---
+
+## Out of Scope
+
+- **v1.4.2 (next patch)**: `/power-engineer uninstall <skill>`, `/power-engineer info <skill>`, `scripts/catalog-diff.sh` (QoL pack items originally slotted for v1.4.2 per project_v140_brainstorm.md). Any drift discovered during v1.4.1 release ceremony.
+- **v1.5.0 (next minor)**: Cluster C — project-implementation advisor, extensibility framework, behavioral-CI wiring, PR-policy formalization (per project_v140_released.md).
+- **v1.2.0 remote tag hygiene**: Still open per project_v130_released.md; defers to a standalone housekeeping commit or v1.4.2.
+- **Permanently out of scope for v1.4.1**: Any code change beyond the two security-review minor items. No README polish beyond version bumps. No catalog changes. No new templates. No subagent-selector changes. No hook-schema changes.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/power-engineer-v1.4.1-upgrade-plan.md`. Execution approach:
+
+**Subagent-Driven (recommended)** — orchestrator dispatches per-task subagents following `docs/superpowers/release-process/templates/executor-prompt-template.md`. Approximately 6-10 dispatches total:
+
+| Phase | Tasks | Model(s) | Dispatch count |
+|---|---|---|---|
+| 0 | 0.1 (branch), 0.2 (shellcheck research), 0.3 (checkpoint) | Sonnet research | 1 |
+| 1 | 1.1 (patch script 1), 1.2 (patch script 2), 1.3 (auditor), 1.4 (checkpoint) | Sonnet Dev + Opus Auditor | 2-3 (Devs may batch) |
+| 2 | 2.1 (CHANGELOG), 2.2 (MIGRATION), 2.3 (template fix), 2.4 (auditor), 2.5 (checkpoint) | Sonnet Dev + Sonnet Auditor | 2-3 |
+| 3 | 3.1 (version bumps), 3.2 (security review), 3.3 (user ckpt), 3.4 (push+PR), 3.5 (dual audit), 3.6 (merge+tag+release), 3.7 (save-phase) | Sonnet Dev + Opus security + Dual-Opus Template E + Opus release ops | 3-4 |
+
+Total estimated: 8-11 dispatches.
+
+**Required executor inputs (orchestrator reads before any dispatch):**
+
+1. This plan file
+2. `docs/superpowers/plans/v1.4.0-security-review.md` (source of the 2 minor items)
+3. Prior retrospective `project_v140_released.md`
+4. Both feedback memories cited in this plan: `feedback_plan_pattern_verification.md`, `feedback_external_api_verification.md`
+5. `CLAUDE.md` (universal AskUserQuestion enforcement, memory management, session orchestration)
+6. `docs/superpowers/release-process/release-process.md` (cross-cutting policy)
+7. `power-engineer/references/modules/subagent-selector.md` (model-assignment decision table)
+
+**Universal AskUserQuestion enforcement:** Every user-facing decision point in this plan uses the AskUserQuestion tool. Plain-text questions in orchestrator responses are forbidden per CLAUDE.md.
+
+**Rollback authority:** Orchestrator MAY execute per-phase rollback only after dual-auditor rejection + user-approved AskUserQuestion. Full-release rollback (post-tag) ALWAYS requires explicit user authorization. Never force-push, never delete tags, never modify other branches without explicit authorization.
+
+---
+
+*End of v1.4.1 plan. Strict patch; 4 phases; ~8-11 subagent dispatches. The plan-template awk-range fix in Task 2.3 is the mandatory in-place dogfood defect fix — do NOT skip.*

--- a/docs/superpowers/plans/power-engineer-v1.4.1-upgrade-plan.md
+++ b/docs/superpowers/plans/power-engineer-v1.4.1-upgrade-plan.md
@@ -51,16 +51,17 @@ Files created or modified, grouped by responsibility:
 
 **Files:** None (git operation)
 
-- [ ] **Step 1: Create branch tracking origin**
+- [ ] **Step 1: Create local branch (no push per user HARD CONSTRAINT)**
 
 ```bash
 git checkout main
 git pull
 git checkout -b v1.4.1-upgrade
-git push -u origin v1.4.1-upgrade
 ```
 
-Expected: `v1.4.1-upgrade` tracks `origin/v1.4.1-upgrade`. This push is the single mid-release exception to the push-at-release-time policy (per `release-process.md` §4).
+Expected: local `v1.4.1-upgrade` branch on base `d91f905` (v1.4.0 squash).
+
+**Push policy for v1.4.1:** User-level HARD CONSTRAINT overrides the `release-process.md` §4 Phase 0 branch-push exception. Branch stays local-only through Phase 0, 1, 2, and the audit steps of Phase 3. First (and only) push happens in Phase 3 Task 3.4 Step 1, immediately before `gh pr create --draft`. Rationale: user-directive tightens the §4 exception; all implementation commits stay locally revertible without coordination with origin.
 
 - [ ] **Step 2: Confirm clean starting state**
 

--- a/docs/superpowers/plans/v1.4.1-security-review.md
+++ b/docs/superpowers/plans/v1.4.1-security-review.md
@@ -1,0 +1,350 @@
+# v1.4.1 Hook Scripts — Security Re-Review
+
+**Auditor:** Opus security-review subagent (v1.4.1 Phase 3 Task 3.2; fresh-context, did not implement)
+**Date:** 2026-04-18
+**Scope:** The v1.4.1 patches to `power-engineer/scripts/hooks/session-end-handoff.sh` + `power-engineer/scripts/hooks/pre-compact-snapshot.sh` (commits `ede5dd1` and `f950864`)
+**Threat model:** Same axes as the v1.4.0 review — shell injection · path traversal · unsafe destructive commands · env var assumptions · error handling · Power Engineer-specific (hostile project dir / git output / race conditions / `state_dir`-as-regular-file) — PLUS four new axes introduced by the v1.4.1 patches:
+  1. PID-suffix attack surface — can `$$` interpolated into a filename enable injection?
+  2. `[[ -s "$_prior_errlog" ]]` fault behavior under `set -euo pipefail` + ERR trap
+  3. `printf '...: %s' "$_prior_errlog"` data-vs-format separation (does the PATH variable enable format-string attacks?)
+  4. `unset _prior_errlog` scope hygiene (leak into `git_field` subshells, ERR trap body, etc.)
+**Methodology:** Line-by-line static review of the two patched files in their v1.4.1 state + per-commit diff inspection + ShellCheck 0.11.0 at default severity (CI gate) and `--include=SC2016` (to re-verify SC2016 suppressions) + 11 runtime exploitation tests executed on macOS Darwin 25.4.0 (arm64) with bash 3.2.57 under `/tmp/v141-sec-review/`. Every test was run from a clean tempdir and verified via the absence of attacker-controlled `/tmp/v141-PWNED*` marker files.
+
+---
+
+## Summary
+
+- 🚨 Critical: 0
+- ⚠️ Minor: 0
+- ✅ Pass: 16 (14 v1.4.0 axes re-verified + 4 new v1.4.1-patch axes)
+
+**Verdict:** RELEASE-SAFE
+
+The v1.4.1 patches resolve both v1.4.0 ⚠️ MINOR items (timestamp-collision clobber; operator observability for silent hook failures) without introducing any new attack surface. The `-$$` filename suffix is a pure decimal integer from the OS PID allocator — never attacker-controllable and never an injection vector. The new prologue (`[[ -s "$_prior_errlog" ]]` test + `printf '...: %s\n' "$_prior_errlog" >&2` call + `unset _prior_errlog`) is data-safe: the format string is a single-quoted literal with a `%s` placeholder, matching the v1.4.0-proven pattern for hostile git output. The `[[ -s ]]` test uses stat, not read, so permission-denied and unreadable-file cases are handled deterministically without triggering the ERR trap. The `unset` at the end of the prologue is defensive hygiene (the variable is never exported, so subshells `(cd … && git …)` never see it regardless). All 11 runtime tests passed: 5 injection attempts blocked, empty/unreadable/regfile edge cases exit 0 cleanly, 50 concurrent invocations produced 50 distinct filenames, and both hooks preserve the `exit 0`-only contract (zero `exit 1`/`exit 2` in executable positions).
+
+ShellCheck at the default severity (info+) is clean (exit 0) on both scripts. The `--severity=style --enable=all` run surfaces SC2250 (brace-preference) warnings that are **pre-existing** in v1.4.0 (same braceless `"$var"` pattern used throughout — see lines 31, 48, 49, 72, 82, 83 etc. in session-end, unchanged since v1.4.0); the v1.4.1 patches inherit that same style consistently, so they neither introduce nor fail to fix a pre-existing style choice. The patches are surgically scoped: 11 added lines in session-end, 12 in pre-compact, all purely additive prologue + a 1-character suffix on one filename line each.
+
+---
+
+## v1.4.1-patch-specific findings
+
+### Finding 1: PID-suffix attack surface
+
+**Verdict:** ✅ PASS
+
+**Evidence:**
+
+- Line 92 (session-end) and line 109 (pre-compact) expand `$$` inside a double-quoted string as a filename suffix: `"${state_dir}/session-handoff-${timestamp_filename}-$$.md"` and `"${state_dir}/pre-compact-${timestamp_filename}-$$.md"`.
+- `$$` is POSIX-defined (§2.5.2) as the decimal PID of the invoking shell, which is pure `[0-9]+`. The OS PID allocator never emits anything other than an integer.
+- The value is interpolated into a filename literal via shell variable expansion; it is never placed in command position, eval'd, or interpolated into a format string.
+- Phase 0 research (`docs/superpowers/plans/v1.4.1-shellcheck-research.md`) confirms `$$` alone produces zero ShellCheck warnings at any severity. Confirmed in my re-run: default `shellcheck` and `--include=SC2016` both exit 0 on both scripts.
+- **Runtime test #8:** Firing 50 backgrounded hook invocations in the same UTC second produced 50 distinct filenames, 50 unique PIDs — no collision. Repeated on pre-compact (test #8b): same result. This is the definitive proof that the patch achieves its stated goal.
+- Because `$$` cannot contain shell metacharacters, command substitution, or format-string tokens, it introduces zero new attack surface. An attacker cannot influence the PID of the running shell process from outside.
+
+### Finding 2: `[[ -s "$_prior_errlog" ]]` test behavior under `set -euo pipefail`
+
+**Verdict:** ✅ PASS
+
+**Evidence:**
+
+- The `[[ -s FILE ]]` test is a bash conditional expression that uses `stat(2)` on FILE and returns true iff the file exists and has size > 0. It returns false (exit 1) under any failure condition (file missing, not a regular file, not readable-by-stat, parent dir permission denied).
+- A false return from `[[ ... ]]` does **not** trigger the ERR trap — the ERR trap fires on the failure of simple commands and pipelines, but `[[ ... ]]` used as the controlling condition of `if` is explicitly excluded per bash manual §3.7.5 ("a compound list executed as part of an `if` test list … does not cause the shell to exit [under set -e]"). This is further reinforced by the fact that the `if` construct itself swallows non-zero exits from its test clause.
+- **Runtime test #5:** Empty log (`touch memory-errors.log` → 0 bytes). Hook runs, `[[ -s ]]` returns false (empty file), no stderr warning, exit 0. stderr byte count: 0. Verified.
+- **Runtime test #6:** `chmod 000` on an existing non-empty log. `[[ -s ]]` still returns true (size metadata is visible via the containing directory's listing even when the file itself is unreadable). Warning fires, exit 0. Verified.
+- **Runtime test #7:** `.power-engineer` exists as a regular file (so `.power-engineer/memory-errors.log` is `file/memory-errors.log` — a path-through-a-file, not a real path). `[[ -s ]]` returns false (ENOTDIR on the stat call), no warning, exit 0. Verified. The hook then proceeds to the `mkdir -p` step which also fails silently and routes to `log_error` → `exit 0`.
+- In none of these paths does the test expression cause the script to terminate abnormally. The ERR trap is not invoked; the exit-0 contract holds.
+
+### Finding 3: `printf '...: %s' "$_prior_errlog"` — data-vs-format separation
+
+**Verdict:** ✅ PASS
+
+**Evidence:**
+
+- The printf call at session-end line 24 and pre-compact line 39 uses the form `printf 'script-name: prior hook errors logged at %s\n' "$_prior_errlog" >&2`.
+- The format string is a **single-quoted literal** — no parameter expansion, no command substitution, no history expansion. It is a fixed string ending in a single `%s` placeholder and `\n`.
+- `$_prior_errlog` is passed as a **positional data argument** to printf, which substitutes it for the `%s`. This is the same pattern the v1.4.0 review validated for `$message`, `$recent_commits`, `$modified_files`, `$branch_name`, etc. printf's `%s` conversion treats its argument as an opaque byte string; it does not re-interpret format tokens that appear within the data.
+- **Runtime test #3 + #3b:** Set `CLAUDE_PROJECT_DIR` to a path containing `$(touch /tmp/v141-PWNED3)`. Hook fires. stderr prints the literal path verbatim, including the `$(...)` chars: `session-end-handoff.sh: prior hook errors logged at /tmp/v141-sec-review/test3/project$(touch /tmp/v141-PWNED3)/.power-engineer/memory-errors.log`. `/tmp/v141-PWNED3` does NOT exist after the hook completes. Same behavior on the pre-compact hook (test #3b): `/tmp/v141-PWNED5` never created.
+- **Runtime test #4:** Seeded log content with `%n`, `%s`, `%x %d %p`, and backticks ``` `touch /tmp/v141-PWNED4` ```. Hook fires. stderr prints the literal PATH to the log (which contains no format chars — it's the absolute filesystem path). `/tmp/v141-PWNED4` does NOT exist. Critical observation: the hook prints the log PATH, not the log CONTENT. Even if an attacker could seed format-string chars into the log content, it would never reach printf as part of the format argument. An attacker would need to control the PATH itself (which is `CLAUDE_PROJECT_DIR`-derived), and that vector is already covered by tests #2, #3, #3b — all of which were blocked.
+- No code path constructs a printf format string from any variable.
+
+### Finding 4: `unset _prior_errlog` scope hygiene
+
+**Verdict:** ✅ PASS
+
+**Evidence:**
+
+- `_prior_errlog` is assigned on one line, read on two lines (the `[[ -s ]]` test and the printf), and `unset` on the fourth line of the prologue. No other references anywhere in either file (verified via `grep -n '_prior_errlog'` → only lines 22-26 in session-end, 37-41 in pre-compact).
+- The variable is **never exported**. Shell variables that are not explicitly `export`ed do not propagate to subprocesses (including the `( cd … && git … )` subshells inside `git_field` and the grouped-redirection write block). Even without the `unset`, these subshells could not observe `_prior_errlog` in their environment — they could only observe it via shell-level copy-on-fork if bash were to copy non-exported vars into the subshell, which it does (subshells inherit the parent shell state). However, the variable is never re-read in those subshells, and the subshells run entirely unrelated logic (`cd`, `git`, `printf '%s' "$fallback"`).
+- The `unset` is therefore defensive hygiene: it prevents any future refactor from accidentally reading the variable outside the prologue, and it ensures that if a subshell were to introspect `env` or `set`, the variable would be absent.
+- No leak vector identified. The variable's lifecycle is strictly bounded to lines 22-26 (session-end) / 37-41 (pre-compact).
+
+---
+
+## Regression check (v1.4.0 threat-model axes re-verified)
+
+| Axis | Re-verified? | Result |
+|---|---|---|
+| Shell injection via commit message | Yes | ✅ PASS — test #1: `$(touch /tmp/v141-PWNED1)` committed → literal text in handoff → marker never created. |
+| Shell injection via `CLAUDE_PROJECT_DIR` | Yes | ✅ PASS — test #2: `CLAUDE_PROJECT_DIR='$(touch /tmp/v141-PWNED2)'` → literal dirname created, no code execution. |
+| Shell injection via metachar in project path | Yes | ✅ PASS — tests #3 and #3b: `project$(touch /tmp/v141-PWNED3)` as part of `CLAUDE_PROJECT_DIR` → literal stderr warning, no execution. |
+| Path traversal | Yes | ✅ PASS — state_dir concatenation `${project_dir}/.power-engineer` is pure string join; `.power-engineer` segment is hard-coded literal so even a hostile `$project_dir` controls only *where* state lives, not its name. |
+| Unsafe destructive commands | Yes | ✅ PASS — no `rm`, no `>`-redirect to anything other than the single handoff/snapshot target file and `memory-errors.log`. `mkdir -p` is idempotent and scoped to `$state_dir`. |
+| Env var assumptions (`CLAUDE_PROJECT_DIR` unset) | Yes | ✅ PASS — `${CLAUDE_PROJECT_DIR:-$PWD}` fallback; `set -u` cannot fire. The new `_prior_errlog` line uses the same default pattern. |
+| Env var assumptions (hostile value) | Yes | ✅ PASS — tests #2, #3, #3b all pass; all interpolations are double-quoted data arguments. |
+| ERR trap fires → exit 0 | Yes | ✅ PASS — trap on line 54 (session-end) / 71 (pre-compact) calls `log_error` then `exit 0`. The new prologue cannot reach the ERR trap (no failing simple commands between lines 22-26); verified by runtime tests #5, #6, #7. |
+| EXIT trap guarantees exit 0 | Yes | ✅ PASS — line 55 (session-end) / 72 (pre-compact): `trap 'exit 0' EXIT`. All 11 runtime tests confirmed exit 0. |
+| Exit-0 contract (no `exit 1` / no `exit 2`) | Yes | ✅ PASS — test #9: `grep -nE '^[^#]*exit [12]'` returns zero matches in both scripts. Only `exit 0` in executable positions. |
+| `state_dir`-exists-as-regular-file | Yes | ✅ PASS — test #7: hook exits 0, state dir not corrupted, `[[ -s ]]` on the non-dir path returns false cleanly. |
+| Hostile git output (commit messages with metachars) | Yes | ✅ PASS — test #1 produced literal text in the code fence. |
+| Race conditions (concurrent invocations) | Yes | ✅ PASS — tests #8 and #8b: 50/50 distinct filenames per hook. **This axis is STRENGTHENED in v1.4.1**: the pre-patch version would have caused 50-way clobber under the same UTC-second; the patch reduces collision probability from `O(1/sec)` to `O(1/(sec·2²²))` (Linux PID space) or effectively zero under bash process lifetimes. |
+| ShellCheck SC2016 suppressions still valid | Yes | ✅ PASS — test #10: `shellcheck --include=SC2016` exits 0 on both scripts. The 6 SC2016 disables documented in the v1.4.0 review (lines 102, 105 in session-end; lines 114, 121, 124, 137 in pre-compact) continue to suppress exactly the same real info-warnings on exactly the same lines. No new SC2016-relevant constructs were introduced by v1.4.1. |
+| Paths with spaces | Yes | ✅ PASS — all `$project_dir`, `$state_dir`, `$_prior_errlog`, `$handoff_file`, `$snapshot_file` interpolations are double-quoted; test #3 used a path containing literal `$(...)` chars which also include spaces-equivalent metacharacters and succeeded. |
+
+---
+
+## Runtime exploitation test log
+
+All tests executed from a clean `/tmp/v141-sec-review/` workspace with no pre-existing PWNED markers. Commands and verbatim outputs below.
+
+### Test 1 — Malicious commit message re-run
+
+```
+$ cd /tmp/v141-sec-review/test1-malicious-commit
+$ git init -q && git config user.email "test@example.com" && git config user.name "Test"
+$ echo "file1" > f.txt && git add f.txt
+$ git commit -q -m '$(touch /tmp/v141-PWNED1)'
+$ git log --oneline
+551f4ca $(touch /tmp/v141-PWNED1)
+$ CLAUDE_PROJECT_DIR="$PWD" bash session-end-handoff.sh
+$ echo "exit: $?"
+exit: 0
+$ [[ -e /tmp/v141-PWNED1 ]] && echo FAIL || echo PASS
+PASS
+$ ls .power-engineer/
+session-handoff-20260418T050606Z-2414.md
+$ grep -A2 "Recent commits" .power-engineer/session-handoff-20260418T050606Z-2414.md
+## Recent commits (last 5)
+
+```
+551f4ca $(touch /tmp/v141-PWNED1)
+```
+```
+
+Result: **PASS**. `/tmp/v141-PWNED1` never created. Commit message appears as literal text inside the code fence. Filename uses new `-$$`-suffix form (`-2414.md`).
+
+### Test 2 — Malicious CLAUDE_PROJECT_DIR re-run
+
+```
+$ cd /tmp/v141-sec-review/test2-malicious-projdir
+$ CLAUDE_PROJECT_DIR='$(touch /tmp/v141-PWNED2)' bash session-end-handoff.sh
+$ echo "exit: $?"
+exit: 0
+$ [[ -e /tmp/v141-PWNED2 ]] && echo FAIL || echo PASS
+PASS
+$ ls '$(touch /tmp/v141-PWNED2)/.power-engineer/'
+session-handoff-20260418T050620Z-2720.md
+```
+
+Result: **PASS**. Literal-named directory `$(touch /tmp/v141-PWNED2)` created (correct because the hostile value is treated as a legitimate path); handoff written inside. `/tmp/v141-PWNED2` never created.
+
+### Test 3 — Malicious `_prior_errlog` path (v1.4.1-patch-specific)
+
+```
+$ mkdir -p '/tmp/v141-sec-review/test3/project$(touch /tmp/v141-PWNED3)/.power-engineer'
+$ echo "prior error" > '/tmp/v141-sec-review/test3/project$(touch /tmp/v141-PWNED3)/.power-engineer/memory-errors.log'
+$ CLAUDE_PROJECT_DIR='/tmp/v141-sec-review/test3/project$(touch /tmp/v141-PWNED3)' \
+    bash session-end-handoff.sh 2>test3-stderr.log
+$ echo "exit: $?"
+exit: 0
+$ cat test3-stderr.log
+session-end-handoff.sh: prior hook errors logged at /tmp/v141-sec-review/test3/project$(touch /tmp/v141-PWNED3)/.power-engineer/memory-errors.log
+$ [[ -e /tmp/v141-PWNED3 ]] && echo FAIL || echo PASS
+PASS
+```
+
+Result: **PASS**. The path's `$(touch ...)` segment appears verbatim in the stderr warning (as literal text — `printf '%s'` treats it as data). `/tmp/v141-PWNED3` never created.
+
+### Test 3b — Same on pre-compact hook
+
+```
+$ CLAUDE_PROJECT_DIR='/tmp/v141-sec-review/test3b/projectB$(touch /tmp/v141-PWNED5)' \
+    bash pre-compact-snapshot.sh 2>test3b-stderr.log
+$ cat test3b-stderr.log
+pre-compact-snapshot.sh: prior hook errors logged at /tmp/v141-sec-review/test3b/projectB$(touch /tmp/v141-PWNED5)/.power-engineer/memory-errors.log
+$ [[ -e /tmp/v141-PWNED5 ]] && echo FAIL || echo PASS
+PASS
+```
+
+Result: **PASS**.
+
+### Test 4 — Format-string attack on log content
+
+```
+$ cat > test4-fmt-string/.power-engineer/memory-errors.log <<'EOF'
+[2026-04-18] error: malformed %n and %s injected here
+crash with %x %d %p
+and backticks `touch /tmp/v141-PWNED4`
+EOF
+$ CLAUDE_PROJECT_DIR="/tmp/v141-sec-review/test4-fmt-string" bash session-end-handoff.sh 2>test4-stderr.log
+$ echo "exit: $?"
+exit: 0
+$ cat test4-stderr.log
+session-end-handoff.sh: prior hook errors logged at /tmp/v141-sec-review/test4-fmt-string/.power-engineer/memory-errors.log
+$ [[ -e /tmp/v141-PWNED4 ]] && echo FAIL || echo PASS
+PASS
+```
+
+Result: **PASS**. The log CONTENT (with `%n`, `%s`, `%x`, backticks) is never read or printed — the hook prints only the log PATH. No format-string interpretation possible.
+
+### Test 5 — Empty log but existing file
+
+```
+$ touch test5-empty-log/.power-engineer/memory-errors.log
+$ ls -la test5-empty-log/.power-engineer/memory-errors.log
+-rw-r--r-- 0 bytes memory-errors.log
+$ CLAUDE_PROJECT_DIR="/tmp/v141-sec-review/test5-empty-log" bash session-end-handoff.sh 2>test5-stderr.log
+$ echo "exit: $?"
+exit: 0
+$ wc -c test5-stderr.log
+       0 test5-stderr.log
+```
+
+Result: **PASS**. `[[ -s ]]` returns false for 0-byte file; no stderr warning; exit 0.
+
+### Test 6 — Unreadable log (chmod 000)
+
+```
+$ echo "some prior error" > test6-unreadable/.power-engineer/memory-errors.log
+$ chmod 000 test6-unreadable/.power-engineer/memory-errors.log
+$ CLAUDE_PROJECT_DIR="/tmp/v141-sec-review/test6-unreadable" bash session-end-handoff.sh 2>test6-stderr.log
+$ echo "exit: $?"
+exit: 0
+$ cat test6-stderr.log
+session-end-handoff.sh: prior hook errors logged at /tmp/v141-sec-review/test6-unreadable/.power-engineer/memory-errors.log
+```
+
+Result: **PASS**. `[[ -s ]]` uses stat (directory entry); chmod 000 on the file itself does not prevent size lookup. Warning fires; exit 0.
+
+### Test 7 — state_dir-exists-as-regular-file
+
+```
+$ cd /tmp/v141-sec-review/test7-regfile
+$ echo "this is a file" > .power-engineer  # regular file, not dir
+$ CLAUDE_PROJECT_DIR="$PWD" bash session-end-handoff.sh 2>test7-stderr.log
+$ echo "exit: $?"
+exit: 0
+$ wc -c test7-stderr.log
+       0 test7-stderr.log
+$ ls -la .power-engineer
+-rw-r--r-- 26 bytes  .power-engineer  # still a file, uncorrupted
+```
+
+Result: **PASS**. `_prior_errlog` path is `.power-engineer/memory-errors.log` — stat fails (ENOTDIR), `[[ -s ]]` returns false, no warning. Then `mkdir -p` fails silently, routes to `log_error` which also fails silently (because it can't create `.power-engineer` either), and the hook exits 0. `.power-engineer` file is not corrupted.
+
+### Test 8 — 50-concurrent session-end invocations
+
+```
+$ cd /tmp/v141-sec-review/test8-concurrent
+$ git init -q && git config user.email "t@e.com" && git config user.name "T"
+$ echo x > a.txt && git add a.txt && git commit -q -m init
+$ mkdir -p .power-engineer
+$ for i in $(seq 1 50); do
+    CLAUDE_PROJECT_DIR="$PWD" bash session-end-handoff.sh &
+  done
+$ wait
+$ ls .power-engineer/session-handoff-*.md | wc -l
+50
+$ ls .power-engineer/session-handoff-*.md | sed 's|.*session-handoff-||; s|-[0-9]*\.md||' | sort -u
+20260418T050802Z
+$ ls .power-engineer/session-handoff-*.md | sed 's|.*-||; s|\.md||' | sort -u | wc -l
+50
+```
+
+Result: **PASS**. 50 invocations, all in the same UTC second (`20260418T050802Z`), 50 unique PID suffixes → 50 distinct filenames. Pre-patch behavior would have produced 1 filename and 49 clobbers.
+
+### Test 8b — Same on pre-compact hook
+
+```
+$ for i in $(seq 1 50); do
+    CLAUDE_PROJECT_DIR="$PWD" bash pre-compact-snapshot.sh &
+  done
+$ wait
+$ ls .power-engineer/pre-compact-*.md | wc -l
+50
+$ ls .power-engineer/pre-compact-*.md | sed 's|.*-||; s|\.md||' | sort -u | wc -l
+50
+```
+
+Result: **PASS**. Both hooks collision-free at 50x concurrency.
+
+### Test 9 — PreCompact `exit 2` / `exit 1` preservation
+
+```
+$ # Grep for executable (non-comment) exit 1 or exit 2:
+$ grep -nE '^[^#]*exit [12]' power-engineer/scripts/hooks/pre-compact-snapshot.sh
+# (no output — zero matches)
+$ grep -nE '^[^#]*exit [12]' power-engineer/scripts/hooks/session-end-handoff.sh
+# (no output — zero matches)
+$ grep -n 'exit 0' power-engineer/scripts/hooks/pre-compact-snapshot.sh
+71:trap 'log_error "unhandled error on line $LINENO (exit_code=$?)"; exit 0' ERR
+72:trap 'exit 0' EXIT
+101:    exit 0
+141:    exit 0
+144:exit 0
+```
+
+Result: **PASS**. Zero `exit 1` / `exit 2` in executable statements. Only `exit 0` appears in command position (trap bodies + explicit exits at mkdir-fail, write-fail, and end-of-script). The exit-2-would-block-compaction constraint is preserved.
+
+### Test 10 — ShellCheck with SC2016 verification
+
+```
+$ shellcheck --version
+ShellCheck - shell script analysis tool
+version: 0.11.0
+
+$ shellcheck power-engineer/scripts/hooks/session-end-handoff.sh
+$ echo "exit: $?"
+exit: 0
+
+$ shellcheck power-engineer/scripts/hooks/pre-compact-snapshot.sh
+$ echo "exit: $?"
+exit: 0
+
+$ shellcheck --include=SC2016 power-engineer/scripts/hooks/session-end-handoff.sh
+$ echo "exit: $?"
+exit: 0
+
+$ shellcheck --include=SC2016 power-engineer/scripts/hooks/pre-compact-snapshot.sh
+$ echo "exit: $?"
+exit: 0
+```
+
+Result: **PASS**. Both scripts exit 0 at default severity (CI gate). `--include=SC2016` (which forces SC2016 to fire even where disabled) returns zero warnings because the narrow, line-specific `# shellcheck disable=SC2016` directives on lines 102, 105 (session-end) and 114, 121, 124, 137 (pre-compact) cleanly catch every instance of the literal markdown-backtick pattern.
+
+**Note on `--severity=style --enable=all`:** This stricter mode surfaces SC2250 (brace preference for variable references) warnings across both scripts. All such warnings exist **identically** in the v1.4.0 state of these files — the patches inherit the existing braceless-but-double-quoted `"$var"` style consistently. SC2250 is a style preference, not a correctness warning, and the project's CI gate runs at default severity. The patches do not regress shellcheck-cleanliness.
+
+---
+
+## Recommendations
+
+### Address before release (🚨 CRITICAL)
+
+None. No release-blocking findings.
+
+### Address in v1.4.2 (⚠️ MINOR)
+
+None. Both v1.4.0 ⚠️ MINOR items are fully resolved by v1.4.1 with no new carryover.
+
+### No action required (✅ PASS)
+
+- Both patches are surgical, additive, and conform to the existing defensive patterns established in v1.4.0 (double-quoted interpolation, single-quoted format strings, `printf '%s' "$var"` data arguments, `${VAR:-default}` fallbacks, ERR + EXIT traps guaranteeing exit 0).
+- `$$` is the correct idiom per POSIX §2.5.2 and the Phase 0 research doc; it is guaranteed unique per OS process, ShellCheck-clean, and cannot be influenced by an attacker.
+- The new `_prior_errlog` prologue is scoped to 4-5 lines in each file, uses only safe primitives (`[[ -s ]]`, `printf '%s'`, `unset`), and cannot trip the ERR trap.
+- All 11 runtime exploitation tests passed with the 5 attacker-placed PWNED markers (`/tmp/v141-PWNED1` through `/tmp/v141-PWNED5`) never materialising.
+- The 50x concurrent invocation test — impossible to pass pre-patch — now passes cleanly on both hooks. This represents a concrete improvement to the defensive posture, not just a maintenance fix.
+- The PreCompact `exit 2`-is-forbidden constraint is preserved: zero `exit [12]` in executable positions in either script (verified by grep + manual read).
+- SC2016 disables from v1.4.0 continue to suppress exactly the same real info-warnings on exactly the same lines; no new SC2016 constructs were introduced.
+
+---
+
+**Final verdict:** RELEASE-SAFE

--- a/docs/superpowers/plans/v1.4.1-shellcheck-research.md
+++ b/docs/superpowers/plans/v1.4.1-shellcheck-research.md
@@ -1,0 +1,216 @@
+# v1.4.1 Hook-script Idiom Research — `$$` vs `$RANDOM` for Filename Uniqueness
+
+**Purpose:** Verify the PID-append idiom before Phase 1 Dev patches the two hook scripts.
+
+**Methodology:** Authoritative sources consulted: GNU Bash Reference Manual (https://www.gnu.org/software/bash/manual/bash.html), zsh Parameters manual (https://zsh.sourceforge.io/Doc/Release/Parameters.html), and POSIX Shell Command Language spec (https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html). ShellCheck 0.x (Homebrew-installed at `/opt/homebrew/bin/shellcheck`) was run with `--severity=style --enable=all`. Empirical tests were executed on macOS Darwin 25.4.0 (arm64) with bash 3.2.57 (system `/bin/bash`) and zsh 5.9 (`/bin/zsh`) as the login shell. Concurrent invocation tests used 10 backgrounded processes (`&` + `wait`) writing PID- and RANDOM-suffixed files to `/tmp/v141-shellcheck-test/`.
+
+**Recommendation:** Use `$$` alone. It is POSIX-defined, unique per process, produces no ShellCheck warnings in the scripts' existing brace style, and is guaranteed unique even for concurrent subshells-as-new-processes (how Claude Code invokes hooks). See Recommendation section for the exact line form.
+
+---
+
+## Summary
+
+- `$$` expands to the PID of the **executing shell process** in both bash and zsh; it is POSIX-defined, unique per concurrent hook invocation, and produces zero ShellCheck warnings when already braced.
+- `$RANDOM` in bash is seeded differently per **new process** (PID+time seed) but produces **identical values** across concurrent **subshells** (`()` forked from the same parent). Claude Code hook invocations are new processes, so collision risk is low — but the subshell collision hazard makes `$RANDOM` a worse default.
+- ShellCheck SC2250 flags the unbraced form `$RANDOM` (use `${RANDOM}` instead) but emits **no warning at all** for `$$`.
+
+---
+
+## Question 1: `$$` in bash
+
+**Answer:** When a script is invoked via `#!/usr/bin/env bash`, `$$` expands to the **PID of the bash process running the script**, not the parent shell's PID. This holds for both bash 3.2 (macOS system) and bash 5.x (Homebrew).
+
+**Empirical evidence:** Ten concurrent invocations of the test script each wrote a distinct file:
+```
+out-20260418T041431-39812.txt  (pid=39812)
+out-20260418T041431-39813.txt  (pid=39813)
+out-20260418T041431-39814.txt  (pid=39814)
+...
+out-20260418T041431-39821.txt  (pid=39821)
+```
+All 10 fell within the **same UTC second** (`041431`) and all 10 filenames were distinct — the timestamp alone would have caused 10-way clobber; `$$` prevented it.
+
+**Citation:** GNU Bash Reference Manual, §3.4.2 Special Parameters:
+> "($$) Expands to the process ID of the shell. In a subshell, it expands to the process ID of the **invoking shell**, not the subshell."
+
+POSIX Shell Command Language, §2.5.2 Special Parameters:
+> "Expands to the decimal process ID of the invoked shell. In a subshell (see Shell Execution Environment), '$' shall expand to the same value as that of the current shell."
+
+Note: POSIX says subshells preserve the parent's `$$`, which is consistent with bash's behaviour: `$$` inside `$(...)` or `()` yields the **outer script's** PID, not the subshell fork's PID. For the hook use case (each hook fires as a new top-level bash process), `$$` is the hook's own PID and is unique.
+
+---
+
+## Question 2: `$$` in zsh (sourced vs executed)
+
+**Answer:** In zsh 5.x, `$$` is set when the shell initialises and does not change. If a user accidentally **sources** the hook script (`source session-end-handoff.sh`), `$$` expands to the **interactive zsh session's PID**, not a new process PID. This means:
+
+- Under normal hook execution (Claude Code forks a new bash process): `$$` = the hook's unique PID. Correct.
+- Under accidental sourcing into zsh: `$$` = the interactive shell's PID. If sourced twice in the same second, the filename would be identical and the second write would **overwrite** the first — a real (if unlikely) clobber.
+
+However, the hook scripts use `#!/usr/bin/env bash` shebangs and are not designed to be sourced. The sourcing scenario is a manual-testing edge case, not a production path.
+
+**Citation:** zsh Parameters manual (https://zsh.sourceforge.io/Doc/Release/Parameters.html):
+> "The process ID of this shell, set when the shell initializes."
+> "Processes forked from the shell without executing a new program, such as command substitutions and commands grouped with (...), are subshells that duplicate the current shell, and thus substitute the same value for $$ as their parent shell."
+
+So sourcing does not create a subshell — it runs in the current shell — and `$$` remains the interactive shell's PID for the duration of the sourced script.
+
+---
+
+## Question 3: ShellCheck warnings
+
+**Test script used:**
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+handoff_file="/tmp/handoff-$(date -u +%Y%m%dT%H%M%SZ)"
+output_pid="${handoff_file}-$$.md"
+output_random="${handoff_file}-$RANDOM.md"
+echo "pid file: ${output_pid}"
+echo "random file: ${output_random}"
+```
+
+**Command:** `shellcheck --severity=style --enable=all /tmp/v141-shellcheck-test/sc-test.sh`
+
+**Verbatim output:**
+```
+In /tmp/v141-shellcheck-test/sc-test.sh line 5:
+output_random="${handoff_file}-$RANDOM.md"
+                               ^-----^ SC2250 (style): Prefer putting braces around variable references even when not strictly required.
+
+Did you mean:
+output_random="${handoff_file}-${RANDOM}.md"
+
+For more information:
+  https://www.shellcheck.net/wiki/SC2250 -- Prefer putting braces around vari...
+```
+
+**On the `$$`-only variant** (`"${handoff_file}-$$.md"`):
+
+```
+(no output — zero warnings)
+```
+
+**On the combined `"${handoff_file}-$$-${RANDOM}.md"` variant:**
+
+```
+(no output — zero warnings)
+```
+
+**Observation:** SC2250 fires only for unbraced `$RANDOM`. `$$` is exempt because `$` is not a valid identifier character, so no brace ambiguity exists. The fix is trivial: use `${RANDOM}` instead of `$RANDOM`. The `$$` form is already clean.
+
+**SC2250 source:** https://www.shellcheck.net/wiki/SC2250 — "Prefer putting braces around variable references even when not strictly required."
+
+---
+
+## Question 4: Empirical concurrent-invocation test
+
+**Command used:**
+```bash
+# Script: /tmp/v141-shellcheck-test/pid-test.sh
+#!/usr/bin/env bash
+ts=$(date -u +%Y%m%dT%H%M%S)
+echo "pid=$$" > "/tmp/v141-shellcheck-test/out-${ts}-$$.txt"
+
+# Invocation:
+for i in $(seq 1 10); do /tmp/v141-shellcheck-test/pid-test.sh & done
+wait
+ls -1 /tmp/v141-shellcheck-test/out-*.txt
+```
+
+**File listing (actual output):**
+```
+/tmp/v141-shellcheck-test/out-20260418T041431-39812.txt
+/tmp/v141-shellcheck-test/out-20260418T041431-39813.txt
+/tmp/v141-shellcheck-test/out-20260418T041431-39814.txt
+/tmp/v141-shellcheck-test/out-20260418T041431-39815.txt
+/tmp/v141-shellcheck-test/out-20260418T041431-39816.txt
+/tmp/v141-shellcheck-test/out-20260418T041431-39817.txt
+/tmp/v141-shellcheck-test/out-20260418T041431-39818.txt
+/tmp/v141-shellcheck-test/out-20260418T041431-39819.txt
+/tmp/v141-shellcheck-test/out-20260418T041431-39820.txt
+/tmp/v141-shellcheck-test/out-20260418T041431-39821.txt
+```
+
+**Observation:** All 10 invocations landed in the same UTC second (`20260418T041431`). The timestamp suffix alone would have produced one filename, causing 9 of 10 writes to silently overwrite each other. With `$$` appended, all 10 filenames are distinct. File count: 10/10.
+
+---
+
+## Question 5: `$$` vs `$RANDOM` tradeoffs
+
+### (a) Is `$$` stable across subshells spawned by the same script?
+
+**Yes — intentionally so.** In bash, `$$` inside `$(...)` or `()` expands to the **outer script's PID**, not the subshell fork's PID. This is the bash/POSIX-defined behaviour.
+
+**Empirical evidence:**
+```bash
+# /tmp/v141-shellcheck-test/subshell-test.sh
+outer_pid=$$
+inner_via_subshell=$(echo "subshell_$$")
+# Result: outer_pid=40332, inner_via_subshell=subshell_40332, match: YES
+```
+
+The hook scripts assign `$$` to a variable at the top level (`handoff_file=...-$$.md`), not inside a command substitution, so this behaviour has no adverse effect. The expansion happens once, in the top-level context, where `$$` is the script's own PID.
+
+**Citation:** Bash Reference Manual §3.4.2: "($$) Expands to the process ID of the shell. In a subshell, it expands to the process ID of the **invoking shell**, not the subshell."
+
+### (b) Is `$RANDOM` seeded per-shell or globally?
+
+**Critical finding:** `$RANDOM` behaviour differs sharply between **new processes** and **subshells**:
+
+**New bash processes** (e.g., `./script.sh &`): Each gets a unique seed derived from PID + startup time. Sequential rapid invocations produce distinct first-RANDOM values:
+```
+bash pid=40840 RANDOM=26920
+bash pid=40841 RANDOM=10991
+bash pid=40842 RANDOM=27829
+```
+
+**Concurrent subshells** (e.g., `(echo $RANDOM) &`): All inherit the **same PRNG state** from the parent at fork time and produce **identical values** when first accessed:
+```
+subshell 1: 14771
+subshell 2: 14771
+subshell 3: 14771
+subshell 4: 14771
+subshell 5: 14771
+```
+
+**Implication for the hook scripts:** Claude Code invokes each hook as a new bash process (not a subshell). In that scenario, `$RANDOM` would produce distinct values. However, the identical-subshell hazard means `$RANDOM` is fragile in scripts that do internal backgrounding — and adds no benefit over `$$`.
+
+The `$RANDOM` file collision test (10 backgrounded new processes) produced 10 unique files in practice. However, the values followed a suspiciously regular arithmetic pattern (`9, 918, 1827, 2735, 3644...` — steps of 909), suggesting the seeding of rapidly spawned processes may be deterministic on this platform. `$$` by contrast is guaranteed unique by the OS PID allocator.
+
+**Citations:**
+
+- Bash Reference Manual §5.2 (Bash Variables): "Each time this parameter is referenced, it expands to a random integer between 0 and 32767. Assigning a value to RANDOM initializes (seeds) the sequence of random numbers. Seeding the random number generator with the same constant value produces the same sequence of values. If RANDOM is unset, it loses its special properties, even if it is subsequently reset."
+- zsh Parameters manual: "A pseudo-random integer from 0 to 32767, newly generated each time this parameter is referenced. The random number generator can be seeded by assigning a numeric value to RANDOM. Subshells that reference RANDOM will result in identical pseudo-random values unless the value of RANDOM is referenced or seeded in the parent shell in between subshell invocations."
+
+---
+
+## Recommendation
+
+**Use `$$` alone.** The exact line form for the Phase 1 Dev to apply to both scripts:
+
+**`session-end-handoff.sh` line 82** — change from:
+```bash
+handoff_file="${state_dir}/session-handoff-${timestamp_filename}.md"
+```
+to:
+```bash
+handoff_file="${state_dir}/session-handoff-${timestamp_filename}-$$.md"
+```
+
+**`pre-compact-snapshot.sh` line 98** — change from:
+```bash
+snapshot_file="${state_dir}/pre-compact-${timestamp_filename}.md"
+```
+to:
+```bash
+snapshot_file="${state_dir}/pre-compact-${timestamp_filename}-$$.md"
+```
+
+**Rationale:**
+1. `$$` is POSIX-defined (§2.5.2) and guaranteed unique per OS process — the kernel never re-uses a PID while the prior process is running.
+2. `$$` produces **zero ShellCheck warnings** at any severity level; `$RANDOM` triggers SC2250 (style) unless braced.
+3. `$$` is stable and deterministic for a given invocation; `$RANDOM` carries a subshell-collision hazard that, while not exercised by Claude Code's normal hook invocation path, would be a latent footgun for anyone who sources or subshells the scripts manually.
+4. `$RANDOM` provides no additional collision protection that `$$` does not already provide — both are unique per new process, but only `$$` is defined by the spec.
+
+**This recommendation matches the plan's default (`$$`).** The orchestrator does not need to update the plan before dispatching the Phase 1 Dev.

--- a/docs/superpowers/release-process/templates/plan-template.md
+++ b/docs/superpowers/release-process/templates/plan-template.md
@@ -235,9 +235,12 @@ git commit -m "<type>(<scope>): <subject>"
 - [ ] **Step 2: Verify the v<X.Y.Z> changelog entry is template-derived (dogfood check)**
 
 ```bash
+# Use the flag-based awk pattern rather than the `/^## \[X.Y.Z\]/,/^## \[/`
+# range form — the range form closes on the start line when start + end regex
+# both match the same `## [` header, truncating the extracted subheads to zero.
 diff \
   <(grep -E '^### ' docs/superpowers/release-process/templates/changelog-entry-template.md) \
-  <(awk '/^## \[<X.Y.Z>\]/,/^## \[/' CHANGELOG.md | grep -E '^### ') \
+  <(awk '/^## \[<X.Y.Z>\]/{flag=1; next} flag && /^## \[/{exit} flag' CHANGELOG.md | grep -E '^### ') \
   && echo "OK: v<X.Y.Z> CHANGELOG structurally derived from template" \
   || echo "FAIL: changelog entry diverges from template shape (dogfooding gap)"
 ```

--- a/power-engineer/scripts/hooks/pre-compact-snapshot.sh
+++ b/power-engineer/scripts/hooks/pre-compact-snapshot.sh
@@ -29,6 +29,17 @@ set -euo pipefail
 # See docs/superpowers/plans/v1.4.0-hooks-research.md for the PreCompact schema
 # + firing semantics (sourced from code.claude.com/docs/en/hooks, 2026-04-16).
 
+# ── Operator observability: surface prior hook failures ──────────────────────
+# If memory-errors.log already has entries from a prior invocation, emit a
+# one-line stderr note so operators notice silent-failure accumulation. This
+# does NOT block the hook (exit 0 on every path is still the contract, and
+# PreCompact exit 2 would BLOCK compaction — we never exit 2).
+_prior_errlog="${CLAUDE_PROJECT_DIR:-$PWD}/.power-engineer/memory-errors.log"
+if [[ -s "$_prior_errlog" ]]; then
+    printf 'pre-compact-snapshot.sh: prior hook errors logged at %s\n' "$_prior_errlog" >&2
+fi
+unset _prior_errlog
+
 # ── Resolve project root ─────────────────────────────────────────────────────
 # CLAUDE_PROJECT_DIR is set by Claude Code at hook invocation. Fall back to the
 # current working directory if the var is unset (e.g., during manual testing).
@@ -95,7 +106,7 @@ fi
 # of a $(cat <<EOF) command substitution. The block avoids heredoc parser
 # quirks around apostrophes in prose, keeps variable expansion explicit, and
 # is ShellCheck-friendly.
-snapshot_file="${state_dir}/pre-compact-${timestamp_filename}.md"
+snapshot_file="${state_dir}/pre-compact-${timestamp_filename}-$$.md"
 
 if ! {
     printf '# Pre-Compact Snapshot — %s\n\n' "$timestamp_iso"

--- a/power-engineer/scripts/hooks/session-end-handoff.sh
+++ b/power-engineer/scripts/hooks/session-end-handoff.sh
@@ -15,6 +15,16 @@ set -euo pipefail
 #     so session termination is never blocked or delayed.
 #   - Uses CLAUDE_PROJECT_DIR (populated by Claude Code) to locate the project.
 
+# ── Operator observability: surface prior hook failures ──────────────────────
+# If memory-errors.log already has entries from a prior invocation, emit a
+# one-line stderr note so operators notice silent-failure accumulation. This
+# does NOT block the hook (exit 0 on every path is still the contract).
+_prior_errlog="${CLAUDE_PROJECT_DIR:-$PWD}/.power-engineer/memory-errors.log"
+if [[ -s "$_prior_errlog" ]]; then
+    printf 'session-end-handoff.sh: prior hook errors logged at %s\n' "$_prior_errlog" >&2
+fi
+unset _prior_errlog
+
 # ── Resolve project root ─────────────────────────────────────────────────────
 # CLAUDE_PROJECT_DIR is set by Claude Code at hook invocation. Fall back to the
 # current working directory if the var is unset (e.g., during manual testing).
@@ -79,7 +89,7 @@ fi
 # a $(cat <<EOF) command substitution. The block avoids heredoc parser quirks
 # around apostrophes in prose, keeps variable expansion explicit, and is
 # ShellCheck-friendly.
-handoff_file="${state_dir}/session-handoff-${timestamp_filename}.md"
+handoff_file="${state_dir}/session-handoff-${timestamp_filename}-$$.md"
 
 if ! {
     printf '# Session Handoff — %s\n\n' "$timestamp_iso"


### PR DESCRIPTION
## Summary

Strict-patch release addressing the two ⚠️ MINOR items from the v1.4.0 security review (`docs/superpowers/plans/v1.4.0-security-review.md`):

1. **Timestamp-collision fix.** Both `session-end-handoff.sh` and `pre-compact-snapshot.sh` now append `$$` (PID) to output filenames, preventing sub-second concurrent-invocation clobber.
2. **Operator observability.** Both hooks emit a one-line stderr warning at start when `.power-engineer/memory-errors.log` has accumulated prior entries. Non-blocking; exit-0 hook contract preserved.

No catalog changes. No new features. No architectural changes. Second dogfood pass of the v1.4.0 release-process templates (CHANGELOG + MIGRATION entries instantiated from `docs/superpowers/release-process/templates/`). Phase 2 dogfooding surfaced a defective awk-range pattern in `plan-template.md` (closes range on start line) — fixed in-place per `release-process.md` §9.

## Test plan

- [x] `shellcheck power-engineer/scripts/hooks/*.sh` clean (no new warnings beyond documented suppressions)
- [x] Concurrent-invocation smoke test: 50 × bash invocations in same UTC second → 50 distinct filenames
- [x] Exit-0 hook contract preserved on every path (no `exit 1`/`exit 2` anywhere)
- [x] `bash tests/run-all.sh` → exit 0 (all 5 lint suites PASS)
- [x] CHANGELOG v1.4.1 dogfood diff against `changelog-entry-template.md` → empty (structural match)
- [x] MIGRATION v1.4.0→v1.4.1 dogfood diff against `migration-template.md` → empty (structural match)
- [x] Opus security re-review: RELEASE-SAFE (0 critical, 0 minor, 16 pass)
- [ ] CI green on this draft PR
- [ ] Dual-Opus Template E end-to-end audit APPROVED (in-flight)

## References

- Plan: `docs/superpowers/plans/power-engineer-v1.4.1-upgrade-plan.md`
- v1.4.0 security review (source of the 2 MINOR items): `docs/superpowers/plans/v1.4.0-security-review.md`
- v1.4.1 shellcheck/`$$`/`$RANDOM` research: `docs/superpowers/plans/v1.4.1-shellcheck-research.md`
- v1.4.1 security re-review: `docs/superpowers/plans/v1.4.1-security-review.md`
- Full changelog: `CHANGELOG.md` (v1.4.1 entry)
- Upgrade path: `docs/MIGRATION.md` (v1.4.0 → v1.4.1 entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)